### PR TITLE
Mount the database volume automatically

### DIFF
--- a/docker-services.yml
+++ b/docker-services.yml
@@ -34,6 +34,8 @@ services:
   db:
     image: postgres:12.4
     restart: "unless-stopped"
+    volumes:
+      - ./app_data/db:/var/lib/postgresql/data
     environment:
       - "POSTGRES_USER=nyu-data-repository"
       - "POSTGRES_PASSWORD=nyu-data-repository"


### PR DESCRIPTION
When using docker for development, the instructions say to create a local folder for a database volume but it's not actually mounted ever until you do it by hand. This can cause errors down the line when, for instance, when you're trying to log-in and you can't access the database because it's not mounted. This MR adds a few lines to the `docker-services.yml` file to mount the database volume in `/app_data/db` by default to avoid having people do it manually.