### PR TITLE
Docs npm postgres 76 79

### DIFF
--- a/docs/development/add-fixtures.md
+++ b/docs/development/add-fixtures.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Create and Add Fixtures
-parent: Testing
+parent: Development
 nav_order: 1
 ---
 # {{ page.title }}

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Testing
+title: Development
 nav_order: 3
 has_children: true
 ---

--- a/docs/development/look-feel.md
+++ b/docs/development/look-feel.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Make Look and Feel Changes
-parent: Testing
+parent: Development
 nav_order: 2
 ---
 # {{ page.title }}

--- a/docs/getting-started/dev-docker-setup.md
+++ b/docs/getting-started/dev-docker-setup.md
@@ -33,8 +33,9 @@ has_toc: true
   pyenv install --skip-existing
   ```
 
-3. Load correct node version in current environment. (Check result with `node --version`)
+3. Configure and load correct node version in current environment. (Check result with `node --version`)
   ```sh
+  echo "legacy-peer-deps = true" >> ~/.npmrc
   nvm install
   ```
 

--- a/docs/getting-started/dev-docker-setup.md
+++ b/docs/getting-started/dev-docker-setup.md
@@ -35,9 +35,8 @@ has_toc: true
   pyenv install --skip-existing
   ```
 
-3. Configure and load correct node version in current environment. (Check result with `node --version`)
+3. Load correct node version in current environment. (Check result with `node --version`)
   ```sh
-  echo "legacy-peer-deps = true" >> ~/.npmrc
   nvm install
   ```
 

--- a/docs/getting-started/dev-docker-setup.md
+++ b/docs/getting-started/dev-docker-setup.md
@@ -70,7 +70,6 @@ has_toc: true
 8.5. Due to a [known bug in the current version of InvenioRDM](https://github.com/inveniosoftware/invenio-files-rest/issues/264) we can only use `setuptools` version smaller then 58.
   ```sh
   pipenv run python3.8 -m pip install 'setuptools~=57.5.0'
-  pipenv install --dev
   ```
 
 9. Complete building application python environment and web assets

--- a/docs/getting-started/dev-docker-setup.md
+++ b/docs/getting-started/dev-docker-setup.md
@@ -20,6 +20,8 @@ has_toc: true
   + NOTE: if after nvm installation you are getting `nvm: not found` you can use the following [troubleshooting tips](https://github.com/nvm-sh/nvm#troubleshooting-on-linux)
 - **Cairo**
   + [Installation instructions](https://invenio-formatter.readthedocs.io/en/latest/installation.html)
+- **Postgres**
+  + [Installation instructions](http://postgresguide.com/setup/install.html)
 
 ## Steps
 


### PR DESCRIPTION
- [x] closes #76 
- ~closes #79~ (this is handled instead in PR #78)
- [x] removes redundant `pipenv install` before `invenio-cli install`
- [x] renames "testing" menu heading with "development" in docs, which seems more accurate atm