### PR TITLE
Add 'Browse all' header button

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,8 +5,8 @@ verify_ssl = true
 
 [dev-packages]
 check-manifest = ">=0.25"
-pytest = "*"
 flask-pytest = "*"
+pytest = "*"
 pytest-invenio = "*"
 selenium = "*"
 
@@ -20,10 +20,10 @@ invenio-records-permissions = "<0.13.0,>=0.12.1"
 invenio-records-resources = "<0.17.0,>=0.16.12"
 marshmallow-utils = "<0.6.0,>=0.5.2"
 nbconvert = {extras = ["execute"], version = ">=4.1.0,<6.0.0"}
+python-dotenv = "*"
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
-python-dotenv = "*"
 
 [requires]
 python_version = "3.8"

--- a/templates/semantic-ui/invenio_app_rdm/footer.html
+++ b/templates/semantic-ui/invenio_app_rdm/footer.html
@@ -7,11 +7,9 @@
   Invenio App RDM is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
 
-
   footer.html copied from https://github.com/inveniosoftware/invenio-app-rdm/blob/v6.0.4/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/footer.html
-on 2021-09-29
-from v6.0.4
-
+  on 2021-09-29
+  from v6.0.4
 #}
 
 <footer class="footer-global">

--- a/templates/semantic-ui/invenio_app_rdm/header.html
+++ b/templates/semantic-ui/invenio_app_rdm/header.html
@@ -64,6 +64,11 @@
                       <a href="{{ item.url }}">{{ item.text|safe }}</a></li>
                       {%- endif %}
                 {%- endfor %}
+                <li class="navbar-item navbar-options">
+                  <a href="{{ url_for('invenio_search_ui.search') }}">
+                    Browse all
+                  </a>
+                </li>
             {%- endblock navbar_nav %}
             <li class="navbar-item navbar-button">
               <ul class="rdm-sign-buttons">

--- a/templates/semantic-ui/invenio_app_rdm/header.html
+++ b/templates/semantic-ui/invenio_app_rdm/header.html
@@ -1,0 +1,94 @@
+{#
+
+  Copyright (C) 2019-2020 CERN.
+  Copyright (C) 2019-2020 Northwestern University.
+
+  Invenio App RDM is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+
+  footer.html copied from https://github.com/inveniosoftware/invenio-app-rdm/blob/v6.0.4/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header.html
+  on 2021-10-01
+  from v6.0.4
+#}
+
+<div>
+  <header class="theme header">
+    <div class="outer-navbar">
+      {%- block navbar %}
+      <nav id="invenio-nav" class="ui inverted menu borderless">
+        <div class="ui grid container">
+        <ul class="navbar-menu">
+            <li class="logo">
+              {%- block navbar_header %}
+              {%- block brand %}
+                {%- if config.THEME_LOGO %}
+                <a class="logo-link" href="/">
+                  <img class="ui medium image rdm-logo"
+                      src="{{ url_for('static', filename=config.THEME_LOGO) }}"/>
+                </a>
+                {%- else %}
+                <a class="logo" href="/">{{ _(config.THEME_SITENAME) }}</a>
+                {%- endif %}
+              {%- endblock brand %}
+              {%- endblock navbar_header %}
+            </li>
+            <li class="navbar-item navbar-search-bar">
+              {%- if config.THEME_SEARCHBAR %}
+                  {%- block navbar_search %}
+                    <div class="navbar-item navbar-search-bar" id="header-search-bar">
+                      <form class="form" action="{{ config.THEME_SEARCH_ENDPOINT }}" role="search">
+                        <div class="ui action icon input">
+                          <input type="text" name="q" placeholder="{{ _('Search') }}">
+                          <button type="submit" class="ui icon search button">
+                            <i class="icon search"></i>
+                          </button>
+                        </div>
+                      </form>
+                    </div>
+
+                  {%- endblock navbar_search %}
+                {%- endif %}
+            </li>
+              {%- block navbar_nav %}
+                {%- for item in current_menu.submenu('main').children|sort(attribute='order') if item.visible recursive %}
+                    {%- if item.children %}
+                  <li class="navbar-item navbar-options">
+                    <div class="dropdown{{ ' active' if item.active else '' }}">
+                      <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                        aria-expanded="false" href="{{ item.url }}">{{ item.text|safe }} <b class="caret"></b></a>
+                      <ul class="dropdown-menu">{{ loop(item.children|sort(attribute='order')) }}</ul>
+                    </div>
+                  </li>
+                    {%- else %}
+                      <li class={{ "navbar-item navbar-options active" if item.active and loop.depth == 0 else "navbar-item" }}>
+                      <a href="{{ item.url }}">{{ item.text|safe }}</a></li>
+                      {%- endif %}
+                {%- endfor %}
+            {%- endblock navbar_nav %}
+            <li class="navbar-item navbar-button">
+              <ul class="rdm-sign-buttons">
+                {%- block navbar_right %}
+                  <li class="navbar-item navbar-button">{%- include config.THEME_HEADER_LOGIN_TEMPLATE %}</li>
+                {%- endblock navbar_right %}
+              </ul>
+            </li>
+
+            <li class="toggle">
+              <input class="menu-btn" type="checkbox" id="menu-btn" />
+              <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label>
+            </li>
+        </ul>
+      </div>
+      </nav>
+      {%- endblock navbar %}
+    </div>
+  {%- block flashmessages %}
+  {%- from "invenio_theme/macros/messages.html" import flashed_messages with context -%}
+  {{ flashed_messages() }}
+  {%- endblock %}
+  </header>
+
+  {%- block breadcrumbs %}
+  {%- include "invenio_theme/breadcrumbs.html" %}
+  {%- endblock breadcrumbs %}
+</div>

--- a/tests/ui/test_front_view.py
+++ b/tests/ui/test_front_view.py
@@ -21,3 +21,8 @@ def test_front_page(base_client):
         "NYU Scholarly Communication and Information Policy"
         in front_view.decode("utf-8")
     )
+
+
+def test_header_menu_button(base_client):
+    front_view = base_client.get("/").data
+    assert "Browse all" in front_view.decode("utf-8")

--- a/tests/ui/test_front_view.py
+++ b/tests/ui/test_front_view.py
@@ -10,14 +10,14 @@
 """View tests of the front page."""
 
 
-def test_view1(base_client):
+def test_front_page(base_client):
     # Depends on 'base_app' fixture
     front_view = base_client.get("/").data
-    print(front_view)
     assert (
         "https://library.nyu.edu/departments/scholarly-communications-information-policy/"
         in front_view.decode("utf-8")
     )
-    assert "NYU Scholarly Communication and Information Policy" in front_view.decode(
-        "utf-8"
+    assert (
+        "NYU Scholarly Communication and Information Policy"
+        in front_view.decode("utf-8")
     )


### PR DESCRIPTION
This PR addresses issue https://github.com/nyudlts/ultraviolet/issues/56, by adding a new template override (`header.html`), extending it to add a new _"Browse all"_ button within the horizontal menu. The functionality of the button is exactly the same as clicking the 🔍  button with no parameters, it has been added for accessibility purposes.

**Minor**: The dependencies within [Pipfile](https://github.com/nyudlts/ultraviolet/blob/main/Pipfile) have been arranged alphabetically to calm my TOC.