### PR TITLE
adds requirement for image magick

### DIFF
--- a/docs/develop/look-feel.md
+++ b/docs/develop/look-feel.md
@@ -80,4 +80,4 @@ Tests should be placed in the `tests/ui` directory.
 
 ## Run the tests
 
-While you're on your checked out branch, it doesn't hurt to run the tests. However, the services must be started for the tests to work. In a separate Terminal tab, navigate back to the main project directory and run `invenio-cli services start` and then `bash test_run.sh`.
+While you're on your checked out branch, it doesn't hurt to run the tests. However, the services must be started for the tests to work. In a separate Terminal tab, navigate back to the main project directory and run `invenio-cli services start` and then `bash run_tests.sh`.

--- a/docs/get-started/dev-docker-setup.md
+++ b/docs/get-started/dev-docker-setup.md
@@ -28,6 +28,8 @@ redirect_from:
   + [Installation instructions](https://invenio-formatter.readthedocs.io/en/latest/installation.html)
 - **Postgres**
   + [Installation instructions](http://postgresguide.com/setup/install.html)
+- **Image Magick**
+  + [Installation instructions](https://imagemagick.org/script/download.php)
 
 ## Steps
 


### PR DESCRIPTION
In response to #86 this PR adds Image Magick as a list of software dependencies needed for UltraViolet 💜 and InvenioRDM. Also, it makes a small correction in the look/ feel documentation that updates based on the re-named bash script file.