### PR TITLE
122 creator roles

### DIFF
--- a/app_data/vocabularies.yaml
+++ b/app_data/vocabularies.yaml
@@ -7,3 +7,6 @@ resourcetypes:
 languages:
   pid-type: lng
   data-file: vocabularies/languages.yaml
+creatorsroles:
+  pid-type: crr
+  data-file: vocabularies/creatorsroles_nyu.yaml

--- a/app_data/vocabularies/creatorsroles_nyu.yaml
+++ b/app_data/vocabularies/creatorsroles_nyu.yaml
@@ -1,0 +1,55 @@
+- id: contactperson
+  props:
+    datacite: ContactPerson
+  title:
+    en: Contact person
+- id: datacollector
+  props:
+    datacite: DataCollector
+  title:
+    en: Data collector
+- id: distributor
+  props:
+    datacite: Distributor
+  title:
+    en: Distributor
+- id: editor
+  props:
+    datacite: Editor
+  title:
+    en: Editor
+- id: hostinginstitution
+  props:
+    datacite: HostingInstitution
+  title:
+    en: Hosting institution
+- id: producer
+  props:
+    datacite: Producer
+  title:
+    en: Producer
+- id: researcher
+  props:
+    datacite: Researcher
+  title:
+    en: Researcher
+- id: researchgroup
+  props:
+    datacite: ResearchGroup
+  title:
+    en: Research group
+- id: rightsholder
+  props:
+    datacite: RightsHolder
+  title:
+    en: Rights holder
+- id: other
+  props:
+    datacite: Other
+  title:
+    en: Other
+- id: vendor
+  props:
+    datacite: ''
+  title:
+    en: Vendor

--- a/docs/project-orientation/policy.md
+++ b/docs/project-orientation/policy.md
@@ -24,3 +24,11 @@ UltraViolet metadata is made available under a [CC0 License](https://creativecom
 #### Metadata versioning and provenance
 
 In order to provide contextual information and align with [FAIR principle R1.2: (Meta)data are associated with detailed provenance](https://www.go-fair.org/fair-principles/r1-2-metadata-associated-detailed-provenance/), metadata records are versioned and may include notes about corrections or amendments. Previous versions of metadata records are made available in in Github. Small errors might be documented in a running version description narrative, while major changes and all updates would be given a new version.
+
+#### Internal application of profile
+
+In NYU Data Services' management and curation of the UltraViolet project, we apply the InvenioRDM metadata schema. Departures and local applications of the schema are documented here.
+
+##### Creator Roles
+
+The `creator role` is a sub-element that comes from the DataCite schema. We define it accordingly.


### PR DESCRIPTION
This PR addresses #122 and the idea that the default DataCite schema for creator role types is unnecessarily long and occludes roles that we want to define for our data. It also creates a place within the docs wiki to define how we will apply the shorter ontology.

The exact changes are:

- Takes out a handful of roles and makes the list shorter
- Adds in Vendor as a role that will be used for our licensed materials