### PR TITLE
32 user roles

### DIFF
--- a/app_data/users.yaml
+++ b/app_data/users.yaml
@@ -5,3 +5,38 @@
     - admin
   allow:
     - superuser-access
+- email: nyudepositor@test.com
+  active: True
+  password: nyudepositor
+  roles:
+    - admin
+  allow:
+    - superuser-access
+- email: nyuviewer@test.com
+  active: True
+  password: nyuviewer
+  roles:
+    - admin
+  allow:
+    - superuser-access
+- email: restdatauser@test.com
+  active: True
+  password: restdatauser
+  roles:
+    - admin
+  allow:
+    - superuser-access
+- email: nyudepositor@test.com
+  active: True
+  password: nyudepositor
+  roles:
+    - admin
+  allow:
+    - superuser-access
+- email: publicviewer@test.com
+  active: True
+  password: publicviewer
+  roles:
+    - admin
+  allow:
+    - superuser-access

--- a/docs/project-orientation/users.md
+++ b/docs/project-orientation/users.md
@@ -1,0 +1,41 @@
+---
+layout: default
+title: User Roles
+parent: Project Orientation
+nav_order: 3
+has_toc: true
+
+---
+# {{ page.title }}
+
+
+## User Roles
+
+Ultraviolet has a series of user roles by default that allow us to test the permissions factory.  This page is an overview of the default roles in Ultraviolet and a description of how the correspond to the NYU use case users. Login with these credentials for local testing and development.
+
+### Admin SuperUser
+- Login: admin@test.com
+- Password: adminpassword
+- Purpose: all permissions to do anything in the system.
+
+### NYU Depositor
+- Login: nyudepositor@test.com
+- Password: nyudepositor
+- Purpose: can see files for anything restricted to NYU
+Permissions to deposit files and create records.
+
+### NYU Viewer
+- Login: nyuviewer@test.com
+- Password: nyuviewer
+- Purpose: Can see files for anything restricted to NYU
+
+### Restricted Data User
+- Login: restdatauser@test.com
+- Password: restdatauser
+- Purpose: User who has agreed to terms of data use
+User can access a specific record for which they have agreed to terms of use
+
+### Public Viewer
+- Login: publicviewer@test.com
+- Password: publicviewer
+- Purpose: Can see any files that are open


### PR DESCRIPTION
This PR addresses issue #32 in which we want to have a default set of users that load automatically and allow us to test the use case permissions.  User roles with fake email addresses and passwords that reflect the anticipated user rolls.  Currently all roles have super admin permissions.  These permissions will need to be changed to align with the roles created in the underlying database.  This PR also creates a page within the documentation that describes the logic behind these roles.