### PR TITLE
Invenio58 required communities

### DIFF
--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -1,0 +1,3 @@
+export const overriddenComponents = {
+    // "InvenioAppRdm.Deposit.CommunityHeader.layout": () => null,
+};

--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -1,3 +1,2 @@
 export const overriddenComponents = {
-    // "InvenioAppRdm.Deposit.CommunityHeader.layout": () => null,
 };

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -93,6 +93,7 @@ PREVIEWER_PREFERENCE = [
 ]
 #community
 COMMUNITIES_GROUPS_ENABLED = True
+DEFAULT_COMMUNITY= 'opendata'
 
 # Disables requirement for user email confirmation
 SECURITY_CONFIRMABLE = False

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -93,7 +93,6 @@ PREVIEWER_PREFERENCE = [
 ]
 #community
 COMMUNITIES_GROUPS_ENABLED = True
-DEFAULT_COMMUNITY= 'opendata'
 
 # Disables requirement for user email confirmation
 SECURITY_CONFIRMABLE = False

--- a/templates/semantic-ui/invenio_app_rdm/javascript.html
+++ b/templates/semantic-ui/invenio_app_rdm/javascript.html
@@ -9,3 +9,4 @@
 {{ webpack['theme.js']}}
 {{ webpack['base-theme-rdm.js']}}
 {{ webpack['i18n_app.js']}}
+{{ webpack['overridable-registry.js'] }}

--- a/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -70,6 +70,16 @@
       // the selection of a community a requirement and to avoid users removing the pre-selected community
       // For more about this approach please read https://jira.nyu.edu/browse/INVENIO-58
       document.addEventListener('DOMContentLoaded', () => {
+        
+        // Redirect if cold navigated to /uploads/new without query string
+        const defaultCommunityId = 'opendata'
+        const url = new URL(window.location.href)
+        // Get the value of 'community' from the query string
+        const communityId = url.searchParams.get('community')
+        // Check if the parameters exist; if not redirect the user to the page and include the default community in the query string
+        if (communityId === null) {
+          window.location.href = `/uploads/new?community=${defaultCommunityId}`
+        }
 
         function removeRemove() {
           const matches = document.querySelectorAll("#communityRequired .community-header-element button:nth-child(2)")

--- a/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -60,29 +60,33 @@
     {{ super() }}
     {{ webpack['invenio-app-rdm-deposit.js'] }}
 
+    {%- if not record.is_published and not record.versions.index %}
+      <script>
+        // as long as the current record is not published and has no previous versions (new record)
+        // when cold navigated to /uploads/new without query string REDIRECT to /uploads/new?community={{communityName}}
+        // pick default community name from environment variables
+        const defaultCommunityName = '{{ config.DEFAULT_COMMUNITY }}'
+        const url = new URL(window.location.href)
+        const communityId = url.searchParams.get("community")
+        // Check if the parameters exist and do something with them
+        if (communityId === null) {
+          window.location.href = `/uploads/new?community=${defaultCommunityName}`
+        }
+      </script>
+    {%- endif %}
+
     <script>
       // This hacky solution removes the "Remove" buttom from the community header in order to make
       // the selection of a community a requirement and to avoid users removing the pre-selected community
       // For more about this approach please read https://jira.nyu.edu/browse/INVENIO-58
       document.addEventListener('DOMContentLoaded', () => {
-        
-        // Redirect if cold navigated to /uploads/new without query string
-        const defaultCommunityId = 'opendata'
-        const url = new URL(window.location.href)
-        // Get the value of 'community' from the query string
-        const communityId = url.searchParams.get('community')
-        const isThisRecordNew = url.pathname.match(/new/)
-        // Check if the parameters exist; if not redirect the user to the page and include the default community in the query string
-        if (isThisRecordNew && communityId === null) {
-          window.location.href = `/uploads/new?community=${defaultCommunityId}`
-        }
-
-        function removeRemove() {
-          const match = document.querySelector("#deposit-form .community-header-element .community-header-button:nth-child(2)");
-          match.remove()
-        }
         // delay removing for 1 sec to allow react to render and selection to happen
-        const timer = setTimeout(removeRemove, 1000);
+        // preventing flashing the button by hidding with CSS above
+        setTimeout(() => {
+          const match = document.querySelectorAll("#deposit-form .community-header-element .community-header-button:nth-child(2)");
+          match && match.remove()
+        }, 1000);
       })
     </script>
 {%- endblock %}
+

--- a/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -78,7 +78,6 @@
         }
 
         function removeRemove() {
-          // const matches = document.querySelectorAll("#deposit-form .community-header-element .community-header-button:nth-child(2)")
           const match = document.querySelector("#deposit-form .community-header-element .community-header-button:nth-child(2)");
           match.remove()
         }

--- a/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -60,18 +60,15 @@
     {{ super() }}
     {{ webpack['invenio-app-rdm-deposit.js'] }}
 
-    {%- if not record.is_published and not record.versions.index %}
+    {%- set communityInURL = request.args.get("community") %}
+    {%- if not record.is_published and not record.versions.index and not communityInURL %}
       <script>
         // as long as the current record is not published and has no previous versions (new record)
         // when cold navigated to /uploads/new without query string REDIRECT to /uploads/new?community={{communityName}}
         // pick default community name from environment variables
         const defaultCommunityName = '{{ config.DEFAULT_COMMUNITY }}'
-        const url = new URL(window.location.href)
-        const communityId = url.searchParams.get("community")
         // Check if the parameters exist and do something with them
-        if (communityId === null) {
-          window.location.href = `/uploads/new?community=${defaultCommunityName}`
-        }
+        window.location.href = `/uploads/new?community=${defaultCommunityName}`
       </script>
     {%- endif %}
 

--- a/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -15,6 +15,34 @@
 {%- extends config.BASE_TEMPLATE %}
 
 {%- block page_body %}
+
+  <style>
+    /*
+      This hacky solution hides the "Remove" button from the community selection header when a community has been
+      This prevents the screen from flashing the button as we wait for the DOM to load and react to finish rendering.
+      This is an initial step to hide the "Remove" button before we use JS (below) to delete it from the DOM
+      For more about this approach please read https://jira.nyu.edu/browse/INVENIO-58
+    */
+    #communityRequired .community-header-element button:nth-child(2) {
+      display: none;
+    }
+
+    /*
+      These css blocks add an asterisc to the Community Header to simbolize to the user it's required
+      For more about this approach please read https://jira.nyu.edu/browse/INVENIO-58
+    */
+    #communityRequired .page-subheader .page-subheader-element:nth-child(2)::after {
+      content: "*";
+      color:red;
+      padding-left: .2em;
+    }
+    #deposit-form .page-subheader-element::after {
+      content: "*";
+      color:red;
+      padding-left: .2em;
+    }
+  </style>
+
   {%- if record %}
   <input id="deposits-record" type="hidden" name="deposits-record" value='{{record | tojson }}'></input>
   {%- endif %}
@@ -36,4 +64,21 @@
 {%- block javascript %}
     {{ super() }}
     {{ webpack['invenio-app-rdm-deposit.js'] }}
+
+    <script>
+      // This hacky solution removes the "Remove" buttom from the community header in order to make
+      // the selection of a community a requirement and to avoid users removing the pre-selected community
+      // For more about this approach please read https://jira.nyu.edu/browse/INVENIO-58
+      document.addEventListener('DOMContentLoaded', () => {
+
+        function removeRemove() {
+          const matches = document.querySelectorAll("#communityRequired .community-header-element button:nth-child(2)")
+          matches.forEach(match => {
+            match.remove()
+          })
+        }
+        // delay removing for 1 sec to allow react to render and selection to happen
+        const timer = setTimeout(removeRemove, 1000);
+      })
+    </script>
 {%- endblock %}

--- a/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -32,9 +32,14 @@
       For more about this approach please read https://jira.nyu.edu/browse/INVENIO-58
     */
     #deposit-form div.page-subheader-element:nth-last-child(2):after {
+      display: inline-block;
+      vertical-align: top;
+      margin: -.2em 0 0 .2em;
       content: "*";
-      color:red;
-      padding-left: .2em;
+      color: #db0363;
+      font-size: .92857143em;
+      font-weight: 700;
+      text-transform: none;
     }
   </style>
 
@@ -80,8 +85,10 @@
         // delay removing for 1 sec to allow react to render and selection to happen
         // preventing flashing the button by hidding with CSS above
         setTimeout(() => {
-          const match = document.querySelectorAll("#deposit-form .community-header-element .community-header-button:nth-child(2)");
-          match && match.remove()
+          const matches = document.querySelectorAll("#deposit-form .community-header-element .community-header-button:nth-child(2)");
+          matches.forEach((match) => {
+            match.remove();
+          })
         }, 1000);
       })
     </script>

--- a/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -23,7 +23,7 @@
       This is an initial step to hide the "Remove" button before we use JS (below) to delete it from the DOM
       For more about this approach please read https://jira.nyu.edu/browse/INVENIO-58
     */
-    #communityRequired .community-header-element button:nth-child(2) {
+    #deposit-form .community-header-element .community-header-button:nth-child(2) {
       display: none;
     }
 
@@ -31,12 +31,7 @@
       These css blocks add an asterisc to the Community Header to simbolize to the user it's required
       For more about this approach please read https://jira.nyu.edu/browse/INVENIO-58
     */
-    #communityRequired .page-subheader .page-subheader-element:nth-child(2)::after {
-      content: "*";
-      color:red;
-      padding-left: .2em;
-    }
-    #deposit-form .page-subheader-element::after {
+    #deposit-form div.page-subheader-element:nth-last-child(2):after {
       content: "*";
       color:red;
       padding-left: .2em;
@@ -76,16 +71,16 @@
         const url = new URL(window.location.href)
         // Get the value of 'community' from the query string
         const communityId = url.searchParams.get('community')
+        const isThisRecordNew = url.pathname.match(/new/)
         // Check if the parameters exist; if not redirect the user to the page and include the default community in the query string
-        if (communityId === null) {
+        if (isThisRecordNew && communityId === null) {
           window.location.href = `/uploads/new?community=${defaultCommunityId}`
         }
 
         function removeRemove() {
-          const matches = document.querySelectorAll("#communityRequired .community-header-element button:nth-child(2)")
-          matches.forEach(match => {
-            match.remove()
-          })
+          // const matches = document.querySelectorAll("#deposit-form .community-header-element .community-header-button:nth-child(2)")
+          const match = document.querySelector("#deposit-form .community-header-element .community-header-button:nth-child(2)");
+          match.remove()
         }
         // delay removing for 1 sec to allow react to render and selection to happen
         const timer = setTimeout(removeRemove, 1000);

--- a/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -60,8 +60,8 @@
     {{ super() }}
     {{ webpack['invenio-app-rdm-deposit.js'] }}
 
-    {%- set communityInURL = request.args.get("community") %}
-    {%- if not record.is_published and not record.versions.index and not communityInURL %}
+    {%- set community_in_url = request.args.get("community") %}
+    {%- if not record.is_published and not record.versions.index and not community_in_url %}
       <script>
         // as long as the current record is not published and has no previous versions (new record)
         // when cold navigated to /uploads/new without query string REDIRECT to /uploads/new?community={{communityName}}


### PR DESCRIPTION
[Ticket Link](https://jira.nyu.edu/browse/INVENIO-58)
This PR depends on #185 to make the form pre-load the community when clicking on the upload buttons for deposit.

This PR will add the following:
- Community Header: red asterisk adjacent to the text to symbolize to the user this is a required field
- Community Header: removed "Remove" button to limit the ability of the user to remove a pre-selected community from the deposit form.

To test this PR:
- pull down changes
- `invenio-cli services start`
- `invenio-cli assets build`
- `invenio-cli run`
- navigate to `127.0.0.1:5000` > login with credentials > MyDashboard > click New Upload
  - [ ] observe how the URL includes query parameters `127.0.0.1:5000/uploads/new?community=opendata`, note that if you have not created that community before in your instance this will render a "Page not found screen"
  - [ ] observe that when a community is selected the "Remove" button no longer is present and user can only change the community
  - [ ] observe that there is a red asterisk next to the helper text simbolizing this is a required (both when selected and non-selected community)

I appreciate the time you take to review my work.
