### PR TITLE
Adjust test script to allow single file or directory of tests

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -48,9 +48,9 @@ if [ $# -eq 0 ]
 then
     pipenv run pytest -p no:cacheprovider
 else
-    if ! [ -d "$1" ]
+    if ! [ -e "$1" ]
     then
-       echo "Path to test is invalid"
+       echo "Path to test(s) is invalid"
        exit 1
     fi
        pipenv run pytest -p no:cacheprovider "$1"


### PR DESCRIPTION
While adding and trying to test a single test file I noticed that the test runner would only accept a directory as an argument and not a single test.

This PR allows the test runner to run a single test file or a directory of them.

This PR is against the working v12 branch.