### PR TITLE
Remove timeouts

### DIFF
--- a/tests/e2e/test_e2e_communities.py
+++ b/tests/e2e/test_e2e_communities.py
@@ -51,7 +51,6 @@ def test_user_cannot_create_community(app, live_server,
         datastore.add_role_to_user(user, role)
         datastore.commit()
 
-    time.sleep(2)
     browser.set_window_size(1920, 3980)
 
     # Log in

--- a/tests/e2e/test_e2e_deposit_form.py
+++ b/tests/e2e/test_e2e_deposit_form.py
@@ -55,7 +55,6 @@ def test_element_not_in_deposit_form1(app, live_server,
         datastore.add_role_to_user(user, role)
         datastore.commit()
 
-    time.sleep(2)
     browser.set_window_size(1920, 3980)
     browser.get(url_for("invenio_app_rdm_records.deposit_create", _external=True))
     browser.find_element(By.NAME, "email").send_keys(email)

--- a/tests/e2e/test_e2e_profile_menu.py
+++ b/tests/e2e/test_e2e_profile_menu.py
@@ -74,6 +74,7 @@ def test_regular_users_do_not_see_administration_item(app, live_server, browser)
         EC.element_to_be_clickable((By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button"))
     )
     submit_button.click()
+    time.sleep(2)
     page_source = browser.page_source
 
     assert "Search UltraViolet" in page_source

--- a/tests/e2e/test_e2e_profile_menu.py
+++ b/tests/e2e/test_e2e_profile_menu.py
@@ -49,6 +49,7 @@ def test_admins_see_administration_item(app, live_server, browser):
         EC.element_to_be_clickable((By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button"))
     )
     submit_button.click()
+    time.sleep(2)
     page_source = browser.page_source
 
     assert "Search UltraViolet" in page_source

--- a/tests/e2e/test_e2e_profile_menu.py
+++ b/tests/e2e/test_e2e_profile_menu.py
@@ -49,7 +49,6 @@ def test_admins_see_administration_item(app, live_server, browser):
         EC.element_to_be_clickable((By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button"))
     )
     submit_button.click()
-    time.sleep(2)
     page_source = browser.page_source
 
     assert "Search UltraViolet" in page_source
@@ -75,7 +74,6 @@ def test_regular_users_do_not_see_administration_item(app, live_server, browser)
         EC.element_to_be_clickable((By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button"))
     )
     submit_button.click()
-    time.sleep(2)
     page_source = browser.page_source
 
     assert "Search UltraViolet" in page_source

--- a/tests/ui/test_tombstone.py
+++ b/tests/ui/test_tombstone.py
@@ -23,8 +23,6 @@ def test_tombstone_page(full_record, client_with_login, services, app, db):
         "removal_reason": {"id": "copyright"}
     }
 
-    time.sleep(2)
-
     service.delete_record(system_identity, record.id, data=tombstone_info)
 
     response = client_with_login.get("/records/" + record['id'])


### PR DESCRIPTION
This removes all the seemingly unnecessary timeouts in our tests. This should reduce the randomly failure due to database timeouts.