### PR TITLE
Code Clean Up

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
       - name: "Run black & tests"
         run: |
           pipenv install --dev
-          pipenv run black --check .
           E2E=yes pipenv run ./run-tests.sh
       - name: "Upload screenshots"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,10 @@ jobs:
         run: |
           invenio-cli install
           invenio-cli translations compile
-      - name: "Run tests"
+      - name: "Run black & tests"
         run: |
           pipenv install --dev
+          pipenv run black --check .
           E2E=yes pipenv run ./run-tests.sh
       - name: "Upload screenshots"
         uses: actions/upload-artifact@v4

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,8 @@ verify_ssl = true
 check-manifest = ">=0.25"
 flask-pytest = "*"
 pytest = ">=6,<9.0.0"
-pytest-invenio = {git = "https://github.com/spilth/pytest-invenio.git", ref="selenium-chrome-options"}
+black = "*"
+pytest-invenio = {editable = true, ref = "selenium-chrome-options", git = "https://github.com/nyudlts/pytest-invenio.git"}
 
 [packages]
 ultraviolet = {editable = true, path="./site"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b8ea8cf520242b67b2e78ee13a056b126ae8946155089b8a512a8391532ad732"
+            "sha256": "6f567e4eba79da4194400e7d92884cb669f922eedc959a24e0ebc96af0c087c7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -4048,6 +4048,39 @@
             "markers": "python_version >= '3.9'",
             "version": "==25.4.0"
         },
+        "black": {
+            "hashes": [
+                "sha256:0a1d40348b6621cc20d3d7530a5b8d67e9714906dfd7346338249ad9c6cedf2b",
+                "sha256:0c0f7c461df55cf32929b002335883946a4893d759f2df343389c4396f3b6b37",
+                "sha256:1032639c90208c15711334d681de2e24821af0575573db2810b0763bcd62e0f0",
+                "sha256:35690a383f22dd3e468c85dc4b915217f87667ad9cce781d7b42678ce63c4170",
+                "sha256:43945853a31099c7c0ff8dface53b4de56c41294fa6783c0441a8b1d9bf668bc",
+                "sha256:51c65d7d60bb25429ea2bf0731c32b2a2442eb4bd3b2afcb47830f0b13e58bfd",
+                "sha256:5bd4a22a0b37401c8e492e994bce79e614f91b14d9ea911f44f36e262195fdda",
+                "sha256:6cb2d54a39e0ef021d6c5eef442e10fd71fcb491be6413d083a320ee768329dd",
+                "sha256:6cced12b747c4c76bc09b4db057c319d8545307266f41aaee665540bc0e04e96",
+                "sha256:7eebd4744dfe92ef1ee349dc532defbf012a88b087bb7ddd688ff59a447b080e",
+                "sha256:80e7486ad3535636657aa180ad32a7d67d7c273a80e12f1b4bfa0823d54e8fac",
+                "sha256:895571922a35434a9d8ca67ef926da6bc9ad464522a5fe0db99b394ef1c0675a",
+                "sha256:92285c37b93a1698dcbc34581867b480f1ba3a7b92acf1fe0467b04d7a4da0dc",
+                "sha256:936c4dd07669269f40b497440159a221ee435e3fddcf668e0c05244a9be71993",
+                "sha256:9815ccee1e55717fe9a4b924cae1646ef7f54e0f990da39a34fc7b264fcf80a2",
+                "sha256:9a323ac32f5dc75ce7470501b887250be5005a01602e931a15e45593f70f6e08",
+                "sha256:a3bb5ce32daa9ff0605d73b6f19da0b0e6c1f8f2d75594db539fdfed722f2b06",
+                "sha256:aa211411e94fdf86519996b7f5f05e71ba34835d8f0c0f03c00a26271da02664",
+                "sha256:ae263af2f496940438e5be1a0c1020e13b09154f3af4df0835ea7f9fe7bfa409",
+                "sha256:cb4f4b65d717062191bdec8e4a442539a8ea065e6af1c4f4d36f0cdb5f71e170",
+                "sha256:d81a44cbc7e4f73a9d6ae449ec2317ad81512d1e7dce7d57f6333fd6259737bc",
+                "sha256:dae49ef7369c6caa1a1833fd5efb7c3024bb7e4499bf64833f65ad27791b1545",
+                "sha256:e3f562da087791e96cefcd9dda058380a442ab322a02e222add53736451f604b",
+                "sha256:ec311e22458eec32a807f029b2646f661e6859c3f61bc6d9ffb67958779f392e",
+                "sha256:f42c0ea7f59994490f4dccd64e6b2dd49ac57c7c84f38b8faab50f8759db245c",
+                "sha256:f9786c24d8e9bd5f20dc7a7f0cdd742644656987f6ea6947629306f937726c03"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==25.11.0"
+        },
         "blinker": {
             "hashes": [
                 "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf",
@@ -4384,6 +4417,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==3.0.3"
         },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505",
+                "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.1.0"
+        },
         "outcome": {
             "hashes": [
                 "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8",
@@ -4399,6 +4440,22 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==24.2"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645",
+                "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.0.4"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85",
+                "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.4.0"
         },
         "pluggy": {
             "hashes": [
@@ -4460,11 +4517,11 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1",
-                "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861"
+                "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2",
+                "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==7.0.0"
+            "version": "==7.1.0"
         },
         "pytest-flask": {
             "hashes": [
@@ -4483,9 +4540,9 @@
             "version": "==0.3.0"
         },
         "pytest-invenio": {
-            "git": "https://github.com/spilth/pytest-invenio.git",
+            "git": "git+https://github.com/nyudlts/pytest-invenio.git",
             "markers": "python_version >= '3.7'",
-            "ref": "0fd3e82f44ed4407c7e6350d7015728cdf67fe90"
+            "ref": "08140f595cb98de92300a12e639857da236cf225"
         },
         "pytest-isort": {
             "hashes": [
@@ -4508,6 +4565,54 @@
             ],
             "markers": "python_version ~= '3.9'",
             "version": "==2.4.0"
+        },
+        "pytokens": {
+            "hashes": [
+                "sha256:0fc71786e629cef478cbf29d7ea1923299181d0699dbe7c3c0f4a583811d9fc1",
+                "sha256:11edda0942da80ff58c4408407616a310adecae1ddd22eef8c692fe266fa5009",
+                "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083",
+                "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1",
+                "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de",
+                "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2",
+                "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a",
+                "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1",
+                "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5",
+                "sha256:30f51edd9bb7f85c748979384165601d028b84f7bd13fe14d3e065304093916a",
+                "sha256:34bcc734bd2f2d5fe3b34e7b3c0116bfb2397f2d9666139988e7a3eb5f7400e3",
+                "sha256:3ad72b851e781478366288743198101e5eb34a414f1d5627cdd585ca3b25f1db",
+                "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68",
+                "sha256:42f144f3aafa5d92bad964d471a581651e28b24434d184871bd02e3a0d956037",
+                "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321",
+                "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc",
+                "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7",
+                "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f",
+                "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918",
+                "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9",
+                "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c",
+                "sha256:682fa37ff4d8e95f7df6fe6fe6a431e8ed8e788023c6bcc0f0880a12eab80ad1",
+                "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1",
+                "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3",
+                "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b",
+                "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb",
+                "sha256:941d4343bf27b605e9213b26bfa1c4bf197c9c599a9627eb7305b0defcfe40c1",
+                "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a",
+                "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4",
+                "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa",
+                "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78",
+                "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe",
+                "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9",
+                "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d",
+                "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975",
+                "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440",
+                "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16",
+                "sha256:da5baeaf7116dced9c6bb76dc31ba04a2dc3695f3d9f74741d7910122b456edc",
+                "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d",
+                "sha256:dcafc12c30dbaf1e2af0490978352e0c4041a7cde31f4f81435c2a5e8b9cabb6",
+                "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6",
+                "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.4.1"
         },
         "selenium": {
             "hashes": [

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -17,6 +17,7 @@ from invenio_rdm_records.config import RDM_FACETS, RDM_SEARCH
 from invenio_records_resources.services.records.facets import CFTermsFacet
 from invenio_vocabularies.services.custom_fields import VocabularyCF
 from invenio_vocabularies.services.facets import VocabularyLabels
+
 # required to use custom permissions
 from ultraviolet_saml.handlers import acs_handler_factory
 
@@ -26,6 +27,7 @@ from ultraviolet.policies import UltraVioletPermissionPolicy
 
 def _(x):  # needed to avoid start time failure with lazy strings
     return x
+
 
 # Flask
 # =====
@@ -37,13 +39,13 @@ def _(x):  # needed to avoid start time failure with lazy strings
 # https://flask.palletsprojects.com/en/2.1.x/config/#SEND_FILE_MAX_AGE_DEFAULT
 SEND_FILE_MAX_AGE_DEFAULT = 300
 
-#load environment variables
+# load environment variables
 load_dotenv()
 
-APP_ENVIRONMENT = os.getenv("APP_ENVIRONMENT","local")
+APP_ENVIRONMENT = os.getenv("APP_ENVIRONMENT", "local")
 SECRET_KEY = os.getenv("FLASK_SECRET_KEY")
 if not SECRET_KEY:
-     raise ValueError("No SECRET_KEY set for Flask application")
+    raise ValueError("No SECRET_KEY set for Flask application")
 
 PERMANENT_SESSION_LIFETIME = timedelta(days=1)
 
@@ -51,17 +53,20 @@ PERMANENT_SESSION_LIFETIME = timedelta(days=1)
 # provided, the allowed hosts variable is set to localhost. In production it
 # should be set to the correct host and it is strongly recommended to only
 # route correct hosts to the application.
-TRUSTED_HOSTS = os.getenv("TRUSTED_HOSTS",['0.0.0.0','localhost','127.0.0.1'])
+TRUSTED_HOSTS = os.getenv("TRUSTED_HOSTS", ["0.0.0.0", "localhost", "127.0.0.1"])
 
-#Search hosts
-#SEARCH_HOSTS = os.getenv("SEARCH_HOSTS",'localhostxx','port':9200,'timeout':160}])
+# Search hosts
+# SEARCH_HOSTS = os.getenv("SEARCH_HOSTS",'localhostxx','port':9200,'timeout':160}])
 
 # Flask-SQLAlchemy
 # ================
 # See https://flask-sqlalchemy.palletsprojects.com/en/2.x/config/
 
 # TODO: Set
-SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI","postgresql+psycopg2://ultraviolet:ultraviolet@localhost/ultraviolet")
+SQLALCHEMY_DATABASE_URI = os.getenv(
+    "SQLALCHEMY_DATABASE_URI",
+    "postgresql+psycopg2://ultraviolet:ultraviolet@localhost/ultraviolet",
+)
 
 
 # Invenio-App
@@ -69,35 +74,35 @@ SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI","postgresql+psycop
 # See https://invenio-app.readthedocs.io/en/latest/configuration.html
 
 APP_DEFAULT_SECURE_HEADERS = {
-    'content_security_policy': {
-        'default-src': [
+    "content_security_policy": {
+        "default-src": [
             "'self'",
-            'data:', # for fonts
+            "data:",  # for fonts
             "'unsafe-inline'",  # for inline scripts and styles
-            "blob:",            # for pdf preview
+            "blob:",  # for pdf preview
             # Add your own policies here (e.g. analytics)
         ],
-        'img-src': [
+        "img-src": [
             "'self'",
-            'data:',
+            "data:",
             "https://*.basemaps.cartocdn.com",
             "https://maps-public.geo.nyu.edu",
             "https://maps-restricted.geo.nyu.edu",
-        ]
+        ],
     },
-    'content_security_policy_report_only': False,
-    'content_security_policy_report_uri': None,
-    'force_file_save': False,
-    'force_https': True,
-    'force_https_permanent': False,
-    'frame_options': 'sameorigin',
-    'frame_options_allow_from': None,
-    'session_cookie_http_only': True,
-    'session_cookie_secure': True,
-    'strict_transport_security': True,
-    'strict_transport_security_include_subdomains': True,
-    'strict_transport_security_max_age': 31556926,  # One year in seconds
-    'strict_transport_security_preload': False,
+    "content_security_policy_report_only": False,
+    "content_security_policy_report_uri": None,
+    "force_file_save": False,
+    "force_https": True,
+    "force_https_permanent": False,
+    "frame_options": "sameorigin",
+    "frame_options_allow_from": None,
+    "session_cookie_http_only": True,
+    "session_cookie_secure": True,
+    "strict_transport_security": True,
+    "strict_transport_security_include_subdomains": True,
+    "strict_transport_security_max_age": 31556926,  # One year in seconds
+    "strict_transport_security_preload": False,
 }
 
 USERS_RESOURCES_GROUPS_ENABLED = True
@@ -107,17 +112,14 @@ USERS_RESOURCES_GROUPS_ENABLED = True
 # See https://python-babel.github.io/flask-babel/#configuration
 
 # Default locale (language)
-BABEL_DEFAULT_LOCALE = 'en'
+# See https://invenio-i18n.readthedocs.io/en/latest/configuration.html
+BABEL_DEFAULT_LOCALE = "en"
 # Default time zone
-BABEL_DEFAULT_TIMEZONE = 'UTC'
+BABEL_DEFAULT_TIMEZONE = "UTC"
 
 
 # Invenio-I18N
 # ============
-# See https://invenio-i18n.readthedocs.io/en/latest/configuration.html
-BABEL_DEFAULT_LOCALE = 'en'
-# Other supported languages (do not include BABEL_DEFAULT_LOCALE in list).
-
 PREVIEWER_CHARDET_BYTES = 8192
 """Number of bytes to read for character encoding detection by `cchardet`."""
 
@@ -131,158 +133,144 @@ SECURITY_CONFIRMABLE = False
 # ==========================
 # See https://inveniordm.docs.cern.ch/customize/authentication/#saml-integration
 
-SSO_SAML_DEFAULT_BLUEPRINT_PREFIX = '/saml'
+SSO_SAML_DEFAULT_BLUEPRINT_PREFIX = "/saml"
 """Base URL for the extensions endpoint."""
 
-SSO_SAML_DEFAULT_METADATA_ROUTE = '/metadata/<idp>'
+SSO_SAML_DEFAULT_METADATA_ROUTE = "/metadata/<idp>"
 """URL route for the metadata request."""
 
-SSO_SAML_DEFAULT_SSO_ROUTE = '/login/<idp>'
+SSO_SAML_DEFAULT_SSO_ROUTE = "/login/<idp>"
 """URL route for the SP login."""
 
-SSO_SAML_DEFAULT_ACS_ROUTE = '/authorized/<idp>'
+SSO_SAML_DEFAULT_ACS_ROUTE = "/authorized/<idp>"
 """URL route to handle the IdP login request."""
 
-SSO_SAML_DEFAULT_SLO_ROUTE = '/slo/<idp>'
+SSO_SAML_DEFAULT_SLO_ROUTE = "/slo/<idp>"
 """URL route for the SP logout."""
 
-SSO_SAML_DEFAULT_SLS_ROUTE = '/sls/<idp>'
+SSO_SAML_DEFAULT_SLS_ROUTE = "/sls/<idp>"
 """URL route to handle the IdP logout request."""
 
-SSO_SAML_IDP_NAME = os.getenv('IDP', 'nyu')
+SSO_SAML_IDP_NAME = os.getenv("IDP", "nyu")
 
 SSO_SAML_IDPS = {
-
     # name your authentication provider
     SSO_SAML_IDP_NAME: {
-
         # Basic info
         "title": "NYU Mock SAML",
         "description": "SAML Authentication Service for NYU Ultraviolet",
         "icon": "static/images/logo_ultraviolet_1word_white.svg",
-
         # path to the file i.e. "./saml/sp.crt"
-        'sp_cert_file': os.getenv('SP_CERT','./certificate.pem'),
-
+        "sp_cert_file": os.getenv("SP_CERT", "./certificate.pem"),
         # path to the file i.e. "./saml/sp.key"
         #'sp_key_file': os.getenv('SP_KEY','./sp.pem'),
-        'sp_key_file': '/opt/ultraviolet/qaultraviolet_dlib_nyu_edu.key',
-
-        'settings': {
+        "sp_key_file": "/opt/ultraviolet/qaultraviolet_dlib_nyu_edu.key",
+        "settings": {
             # If strict is True, then the Python Toolkit will reject unsigned
             # or unencrypted messages if it expects them to be signed or encrypted.
             # Also it will reject the messages if the SAML standard is not strictly
             # followed. Destination, NameId, Conditions ... are validated too.
-            'strict': False,
-
+            "strict": False,
             # Enable debug mode (outputs errors).
-            'debug': True,
-
+            "debug": True,
             # Service Provider Data that we are deploying.
-            'sp': {
-
+            "sp": {
                 # Specifies the constraints on the name identifier to be used to
                 # represent the requested subject.
                 # Take a look on https://github.com/onelogin/python-saml/blob/master/src/onelogin/saml2/constants.py
                 # to see the NameIdFormat that are supported.
-                'NameIDFormat': 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+                "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
             },
-
             # Identity Provider Data that we want connected with our SP.
-            'idp': {
-
+            "idp": {
                 # Identifier of the IdP entity  (must be a URI)
-                'entityId': os.getenv("IDP_METADATA",'http://localhost:8080/simplesaml/saml2/idp/metadata.php'),
-
+                "entityId": os.getenv(
+                    "IDP_METADATA",
+                    "http://localhost:8080/simplesaml/saml2/idp/metadata.php",
+                ),
                 # SSO endpoint info of the IdP. (Authentication Request protocol)
-                'singleSignOnService': {
-
+                "singleSignOnService": {
                     # URL Target of the IdP where the Authentication Request Message
                     # will be sent.
-                    'url': os.getenv("IDP_SSO",'http://localhost:8080/simplesaml/saml2/idp/SSOService.php'),
-
+                    "url": os.getenv(
+                        "IDP_SSO",
+                        "http://localhost:8080/simplesaml/saml2/idp/SSOService.php",
+                    ),
                     # SAML protocol binding to be used when returning the <Response>
                     # message. OneLogin Toolkit supports the HTTP-Redirect binding
                     # only for this endpoint.
-                    'binding':
-                        'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
                 },
-
                 # SLO endpoint info of the IdP.
-                'singleLogoutService': {
+                "singleLogoutService": {
                     # URL Location where the <LogoutRequest> from the IdP will be sent (IdP-initiated logout)
-                    "url": os.getenv("IDP_SLO","http://localhost:8080/simplesaml/saml2/idp/SingleLogoutService.php"),
-
+                    "url": os.getenv(
+                        "IDP_SLO",
+                        "http://localhost:8080/simplesaml/saml2/idp/SingleLogoutService.php",
+                    ),
                     # SAML protocol binding to be used when returning the <Response>
                     # message. OneLogin Toolkit supports the HTTP-Redirect binding
                     # only for this endpoint.
-                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
                 },
                 # Public X.509 certificate of the IdP
-                'x509cert': os.getenv('IDP_X509_CERT_SINGLE','')
+                "x509cert": os.getenv("IDP_X509_CERT_SINGLE", ""),
             },
-
             # Security settings
-             # Security settings
             # more on https://github.com/onelogin/python-saml
-            'security': {
-                'allowRepeatAttributeName': True,
-                'authnRequestsSigned': False,
-                'failOnAuthnContextMismatch': False,
-                'logoutRequestSigned': False,
-                'logoutResponseSigned': False,
-                'metadataCacheDuration': None,
-                'metadataValidUntil': None,
-                'nameIdEncrypted': False,
-                'requestedAuthnContext': False,
-                'requestedAuthnContextComparison': 'exact',
-                'signMetadata': False,
-                'signatureAlgorithm':
-                    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
-                'wantAssertionsEncrypted': False,
-                'wantAssertionsSigned': False,
-                'wantAttributeStatement': False,
-                'wantMessagesSigned': False,
-                'wantNameId': True,
-                'wantNameIdEncrypted': False,
-                'digestAlgorithm':
-                    'http://www.w3.org/2001/04/xmlenc#sha256'
+            "security": {
+                "allowRepeatAttributeName": True,
+                "authnRequestsSigned": False,
+                "failOnAuthnContextMismatch": False,
+                "logoutRequestSigned": False,
+                "logoutResponseSigned": False,
+                "metadataCacheDuration": None,
+                "metadataValidUntil": None,
+                "nameIdEncrypted": False,
+                "requestedAuthnContext": False,
+                "requestedAuthnContextComparison": "exact",
+                "signMetadata": False,
+                "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+                "wantAssertionsEncrypted": False,
+                "wantAssertionsSigned": False,
+                "wantAttributeStatement": False,
+                "wantMessagesSigned": False,
+                "wantNameId": True,
+                "wantNameIdEncrypted": False,
+                "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
             },
         },
-
         # Account Mapping as per NYU's available mappings. Please take a look here https://wikis.nyu.edu/download/attachments/40274104/SAMLShibbolethIntegrationGuidev2.1.pdf?version=1&modificationDate=1517176083918&api=v2
         "mappings": {
             "email": os.getenv("IDP_SAML_EMAIL", "urn:oid:1.3.6.1.7"),
             "name": os.getenv("IDP_SAML_NAME", "urn:oid:2.5.4.42"),
             "surname": os.getenv("IDP_SAML_SURNAME", "urn:oid:2.5.4.4"),
-            "external_id": os.getenv("IDP_SAML_EXTERNALID", "urn:oid:0.9.2342.19200300.100.1.1")
+            "external_id": os.getenv(
+                "IDP_SAML_EXTERNALID", "urn:oid:0.9.2342.19200300.100.1.1"
+            ),
         },
-
         # Default Affiliation to be assigned to all SAML logged in users - remove this if not required
         "default_affiliation": "New York University",
-
         # This is used to automatically set email and profile visibility to public to all SAML logged in users - remove this if not required
         "default_visibility": "public",
-
         # Inject your remote_app to handler
         # Note: keep in mind the string should match
         # given name for authentication provider
-        'acs_handler': acs_handler_factory(SSO_SAML_IDP_NAME),
-
+        "acs_handler": acs_handler_factory(SSO_SAML_IDP_NAME),
         # Auto confirms all SAML logged in users
-        'auto_confirm': True
+        "auto_confirm": True,
     }
 }
 
-if os.getenv('IDP_X509_CERT_SIGNING',''):
-    SSO_SAML_IDPS[SSO_SAML_IDP_NAME]['settings']['idp']['x509certMulti'] = {
-    'signing': [os.getenv('IDP_X509_CERT_SIGNING')],
-    'encryption': [os.getenv('IDP_X509_CERT_ENCRYPTION')]
+if os.getenv("IDP_X509_CERT_SIGNING", ""):
+    SSO_SAML_IDPS[SSO_SAML_IDP_NAME]["settings"]["idp"]["x509certMulti"] = {
+        "signing": [os.getenv("IDP_X509_CERT_SIGNING")],
+        "encryption": [os.getenv("IDP_X509_CERT_ENCRYPTION")],
     }
 
 SSO_SAML_ROLES = {
-        # Default role to be assigned to all SAML logged in users - remove this if not required
-        SSO_SAML_IDP_NAME: os.getenv("DEFAULT_SAML_ROLE", "defaultsamlrole"),
+    # Default role to be assigned to all SAML logged in users - remove this if not required
+    SSO_SAML_IDP_NAME: os.getenv("DEFAULT_SAML_ROLE", "defaultsamlrole"),
 }
 
 # The following is a hacky implementation. It should be False for a fresh invenio installation. After creating a community and adding the nyuusers role to the community, add the community ID as a list here
@@ -302,22 +290,22 @@ THEME_SITENAME = "UltraViolet"
 # Frontpage title
 THEME_FRONTPAGE_TITLE = "Search UltraViolet"
 # Header logo
-THEME_LOGO = 'images/logo_ultraviolet_1word_white.svg'
+THEME_LOGO = "images/logo_ultraviolet_1word_white.svg"
 
 # ===============
 # See https://invenio-app-rdm.readthedocs.io/en/latest/configuration.html
 
 # Instance's theme entrypoint file. Path relative to the ``assets/`` folder.
-INSTANCE_THEME_FILE = './less/theme.less'
+INSTANCE_THEME_FILE = "./less/theme.less"
 
 
 # Invenio-Records-Resources
 # =========================
 # See https://github.com/inveniosoftware/invenio-records-resources/blob/master/invenio_records_resources/config.py
 
-SITE_UI_URL = os.getenv("SITE_UI_URL","https://127.0.0.1:5000")
+SITE_UI_URL = os.getenv("SITE_UI_URL", "https://127.0.0.1:5000")
 
-SITE_API_URL = os.getenv("SITE_API_URL","https://127.0.0.1:5000/api")
+SITE_API_URL = os.getenv("SITE_API_URL", "https://127.0.0.1:5000/api")
 
 APP_RDM_DEPOSIT_FORM_DEFAULTS = {
     "publication_date": lambda: datetime.now().strftime("%Y-%m-%d"),
@@ -325,10 +313,12 @@ APP_RDM_DEPOSIT_FORM_DEFAULTS = {
         {
             "id": "cc-by-4.0",
             "title": "Creative Commons Attribution 4.0 International",
-            "description": ("The Creative Commons Attribution license allows "
-                            "re-distribution and re-use of a licensed work "
-                            "on the condition that the creator is "
-                            "appropriately credited."),
+            "description": (
+                "The Creative Commons Attribution license allows "
+                "re-distribution and re-use of a licensed work "
+                "on the condition that the creator is "
+                "appropriately credited."
+            ),
             "link": "https://creativecommons.org/licenses/by/4.0/legalcode",
         }
     ],
@@ -336,13 +326,13 @@ APP_RDM_DEPOSIT_FORM_DEFAULTS = {
 }
 
 # See https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/config.py
-APP_RDM_DEPOSIT_FORM_AUTOCOMPLETE_NAMES = 'search' # "search_only" or "off"
+APP_RDM_DEPOSIT_FORM_AUTOCOMPLETE_NAMES = "search"  # "search_only" or "off"
 
 # Invenio-RDM-Records
 # ===================
 # See https://inveniordm.docs.cern.ch/customize/dois/
 # DOI disabled and not configured
-datacite_enabled = os.getenv("DATACITE_ENABLED","false")
+datacite_enabled = os.getenv("DATACITE_ENABLED", "false")
 
 if datacite_enabled.lower() == "true":
     datacite_enabled = True
@@ -351,18 +341,18 @@ else:
 
 DATACITE_ENABLED = datacite_enabled
 
-DATACITE_USERNAME = os.getenv("DATACITE_USERNAME","")
-DATACITE_PASSWORD = os.getenv("DATACITE_PASSWORD","")
-DATACITE_PREFIX = os.getenv("DATACITE_PREFIX","")
-DATACITE_TEST_MODE = os.getenv("DATACITE_TEST_MODE",True)
-DATACITE_DATACENTER_SYMBOL = os.getenv("DATACITE_DATACENTER_SYMBOL","")
+DATACITE_USERNAME = os.getenv("DATACITE_USERNAME", "")
+DATACITE_PASSWORD = os.getenv("DATACITE_PASSWORD", "")
+DATACITE_PREFIX = os.getenv("DATACITE_PREFIX", "")
+DATACITE_TEST_MODE = os.getenv("DATACITE_TEST_MODE", True)
+DATACITE_DATACENTER_SYMBOL = os.getenv("DATACITE_DATACENTER_SYMBOL", "")
 
 PROPAGATE_EXCEPTIONS = True
 PIDSTORE_DATACITE_URL = "https://api.test.datacite.org"
 
 APP_RDM_DEPOSIT_FORM_QUOTA = {
-     "maxFiles": 100,
-     "maxStorage": 10 ** 9 * 50,
+    "maxFiles": 100,
+    "maxStorage": 10**9 * 50,
 }
 
 # Authentication - Invenio-Accounts and Invenio-OAuthclient
@@ -370,7 +360,7 @@ APP_RDM_DEPOSIT_FORM_QUOTA = {
 # See: https://inveniordm.docs.cern.ch/customize/authentication/
 
 
-#Allow download all
+# Allow download all
 RDM_ARCHIVE_DOWNLOAD_ENABLED = True
 
 # Allow access to old admin panel
@@ -387,10 +377,14 @@ ADMIN_PERMISSION_FACTORY = "ultraviolet.policies.ultraviolet_admin_permission_fa
 ACCOUNTS_LOCAL_LOGIN_ENABLED = os.getenv("ACCOUNTS_LOCAL_LOGIN_ENABLED", True)
 
 # Default to True in Dev but override to False in Prod
-SECURITY_RECOVERABLE = os.getenv("SECURITY_RECOVERABLE", True)  # local login: allow users to reset the password
+SECURITY_RECOVERABLE = os.getenv(
+    "SECURITY_RECOVERABLE", True
+)  # local login: allow users to reset the password
 
 # Default to True in Dev but override to False in Prod
-SECURITY_CHANGEABLE = os.getenv("SECURITY_CHANGEABLE", True)  # local login: allow users to change password
+SECURITY_CHANGEABLE = os.getenv(
+    "SECURITY_CHANGEABLE", True
+)  # local login: allow users to change password
 
 SECURITY_REGISTERABLE = False  # local login: allow users to register
 SECURITY_CONFIRMABLE = False  # require users to confirm their e-mail address
@@ -402,7 +396,10 @@ SECURITY_CONFIRMABLE = False  # require users to confirm their e-mail address
 OAUTHCLIENT_REMOTE_APPS = {}  # configure external login providers
 
 from invenio_oauthclient.views.client import auto_redirect_login
-ACCOUNTS_LOGIN_VIEW_FUNCTION = auto_redirect_login  # autoredirect to external login if enabled
+
+ACCOUNTS_LOGIN_VIEW_FUNCTION = (
+    auto_redirect_login  # autoredirect to external login if enabled
+)
 OAUTHCLIENT_AUTO_REDIRECT_TO_EXTERNAL_LOGIN = False  # autoredirect to external login
 
 # Inregrity files report
@@ -432,26 +429,24 @@ SEARCH_INDEX_PREFIX = "ultraviolet-"
 
 USERS_RESOURCES_ADMINISTRATION_ENABLED = True
 
-#build webpack no symlinks (only needed in production)
-if APP_ENVIRONMENT == 'global':
-  COLLECT_STORAGE = 'flask_collect.storage.file'
-  COLLECT_STATIC_ROOT = os.getenv("COLLECT_STATIC_ROOT", '/opt/static')
+# build webpack no symlinks (only needed in production)
+if APP_ENVIRONMENT == "global":
+    COLLECT_STORAGE = "flask_collect.storage.file"
+    COLLECT_STATIC_ROOT = os.getenv("COLLECT_STATIC_ROOT", "/opt/static")
 
-if APP_ENVIRONMENT == 'local':
-  RDM_RECORDS_USER_FIXTURE_PASSWORDS = {
-   'adminUV@test.com': 'adminUV'
-  }
+if APP_ENVIRONMENT == "local":
+    RDM_RECORDS_USER_FIXTURE_PASSWORDS = {"adminUV@test.com": "adminUV"}
 
-#custom pages
+# custom pages
 PAGES_DEFAULT_TEMPLATE = "invenio_app_rdm/default_static_page.html"
 """Default template to render."""
- 
+
 PAGES_TEMPLATES = [
-     ("invenio_app_rdm/default_static_page.html", "Default"),
+    ("invenio_app_rdm/default_static_page.html", "Default"),
 ]
- 
+
 APP_RDM_PAGES = {
-     "documentation-api": "/documentation-api",
+    "documentation-api": "/documentation-api",
 }
 
 RATELIMIT_ENABLED = False
@@ -459,29 +454,31 @@ RATELIMIT_ENABLED = False
 # UltraViolet custom vars
 # =======================
 
-UV_VERSION              = open(".uv-version", "r").read().strip()
-UV_DEPOSIT_REQUEST      = 'https://nyu.qualtrics.com/jfe/form/SV_exhm5HuMKRdW0hU'
-UV_FAQS                 = 'https://guides.nyu.edu/ultraviolet/faq'
+UV_VERSION = open(".uv-version", "r").read().strip()
+UV_DEPOSIT_REQUEST = "https://nyu.qualtrics.com/jfe/form/SV_exhm5HuMKRdW0hU"
+UV_FAQS = "https://guides.nyu.edu/ultraviolet/faq"
 
-RDM_HOMEPAGE            = 'https://inveniosoftware.org/products/rdm'
-DATA_SERVICES_HOMEPAGE  = 'https://guides.nyu.edu/dataservices'
+RDM_HOMEPAGE = "https://inveniosoftware.org/products/rdm"
+DATA_SERVICES_HOMEPAGE = "https://guides.nyu.edu/dataservices"
 
 # About UltraViolet
-UV_DEPOSIT_ASSISTANCE   = 'https://library.answers.nyu.edu/form?queue_id=6256'
-UV_SERVICE_POLICIES     = 'https://guides.nyu.edu/ultraviolet/policies'
-UV_DOCS                 = 'https://guides.nyu.edu/ultraviolet/'
-UV_TECH_DOCS            = 'https://nyudlts.github.io/ultraviolet/'
+UV_DEPOSIT_ASSISTANCE = "https://library.answers.nyu.edu/form?queue_id=6256"
+UV_SERVICE_POLICIES = "https://guides.nyu.edu/ultraviolet/policies"
+UV_DOCS = "https://guides.nyu.edu/ultraviolet/"
+UV_TECH_DOCS = "https://nyudlts.github.io/ultraviolet/"
 
 # Partnerships
-DLTS_HOMEPAGE           = 'https://wp.nyu.edu/library-dlts/'
-DS_HOMEPAGE             = 'https://guides.nyu.edu/dataservices'
-DCN_HOMEPAGE            = 'https://datacurationnetwork.org/'
-RDM_DOCS_HOMEPAGE       = 'http://inveniordm.docs.cern.ch'
+DLTS_HOMEPAGE = "https://wp.nyu.edu/library-dlts/"
+DS_HOMEPAGE = "https://guides.nyu.edu/dataservices"
+DCN_HOMEPAGE = "https://datacurationnetwork.org/"
+RDM_DOCS_HOMEPAGE = "http://inveniordm.docs.cern.ch"
 
 # Resources
-UV_DEPOSIT_GUIDE        = 'https://guides.nyu.edu/ultraviolet/deposit'
-SCIP_HOMEPAGE           = 'https://library.nyu.edu/departments/scholarly-communications-information-policy/'
-NYU_LIBRARIES_HOMEPAGE  = 'https://library.nyu.edu'
+UV_DEPOSIT_GUIDE = "https://guides.nyu.edu/ultraviolet/deposit"
+SCIP_HOMEPAGE = (
+    "https://library.nyu.edu/departments/scholarly-communications-information-policy/"
+)
+NYU_LIBRARIES_HOMEPAGE = "https://library.nyu.edu"
 
 # Max file size for displaying download buttons and link (50 GB)
 MAX_FILE_SIZE = 50 * 1024 * 1024 * 1024
@@ -499,7 +496,7 @@ GEOSERVER_RESTRICTED_URL = "https://maps-restricted.geo.nyu.edu/geoserver/sdr"
 
 RDM_NAMESPACES = {
     "geospatial": "https://example.com/",
-    "geoserver": "https://geoserver.org/"
+    "geoserver": "https://geoserver.org/",
 }
 
 RDM_CUSTOM_FIELDS = [
@@ -507,7 +504,7 @@ RDM_CUSTOM_FIELDS = [
         name="geospatial:resource_type",
         vocabulary_id="geospatialresourcetypes",
         dump_options=True,
-        multiple=False
+        multiple=False,
     ),
     GeoServerCF(name="geoserver", server=GEOSERVER_PUBLIC_URL),
 ]
@@ -515,50 +512,58 @@ RDM_CUSTOM_FIELDS = [
 RDM_CUSTOM_FIELDS_UI = [
     {
         "section": "Geospatial",
-        "fields": [{
-            "field": "geospatial:resource_type",
-            "ui_widget": "Dropdown",
-            "template": "/geospatial_resource_type.html",
-            "props": {
-                "label": "Resource Type",
-                "placeholder": "lidar",
-                "description": "The type of geospatial data",
-                "search": False,
-                "multiple": False,
-                "clearable": True
+        "fields": [
+            {
+                "field": "geospatial:resource_type",
+                "ui_widget": "Dropdown",
+                "template": "/geospatial_resource_type.html",
+                "props": {
+                    "label": "Resource Type",
+                    "placeholder": "lidar",
+                    "description": "The type of geospatial data",
+                    "search": False,
+                    "multiple": False,
+                    "clearable": True,
+                },
             }
-        }]
+        ],
     },
     {
         "section": "GeoServer",
         "hide_from_landing_page": True,
-        "fields": [{
-            "field": "geoserver",
-            "ui_widget": "GeoServerFields",
-            "props": {
-                "serverUrl": GEOSERVER_PUBLIC_URL,
-                "label": _("GeoServer"),
-                "layer": {
-                    "label": _("Layer Name"),
-                    "placeholder": _("sdr:nyu_2451_12345"),
-                    "description": _("The name of the layer in GeoServer")
-                },
-                "has_wms": {
-                    "label": "Has WMS layer?",
-                    "description": "Is this layer available via WMS?"
-                },
-                "has_wfs": {
-                    "label": "Has WFS layer?",
-                    "description": "Is this layer available via WFS?"
-                },
-                "bounds": {
-                    "label": _("Layer Bounds"),
-                    "placeholder": _("ENVELOPE(-178.2176, -66.969275, 71.406235818, 18.921781818)"),
-                    "description": _("The ENVELOPE that defines the boundaries of this layer")
+        "fields": [
+            {
+                "field": "geoserver",
+                "ui_widget": "GeoServerFields",
+                "props": {
+                    "serverUrl": GEOSERVER_PUBLIC_URL,
+                    "label": _("GeoServer"),
+                    "layer": {
+                        "label": _("Layer Name"),
+                        "placeholder": _("sdr:nyu_2451_12345"),
+                        "description": _("The name of the layer in GeoServer"),
+                    },
+                    "has_wms": {
+                        "label": "Has WMS layer?",
+                        "description": "Is this layer available via WMS?",
+                    },
+                    "has_wfs": {
+                        "label": "Has WFS layer?",
+                        "description": "Is this layer available via WFS?",
+                    },
+                    "bounds": {
+                        "label": _("Layer Bounds"),
+                        "placeholder": _(
+                            "ENVELOPE(-178.2176, -66.969275, 71.406235818, 18.921781818)"
+                        ),
+                        "description": _(
+                            "The ENVELOPE that defines the boundaries of this layer"
+                        ),
+                    },
                 },
             }
-        }]
-    }
+        ],
+    },
 ]
 
 RDM_FACETS = {
@@ -575,10 +580,7 @@ RDM_FACETS = {
     },
 }
 
-RDM_SEARCH = {
-    **RDM_SEARCH,
-    "facets": RDM_SEARCH["facets"] + ["geospatial"]
-}
+RDM_SEARCH = {**RDM_SEARCH, "facets": RDM_SEARCH["facets"] + ["geospatial"]}
 
 # Enable the browsing of Subcommunities in Communities
 COMMUNITIES_SHOW_BROWSE_MENU_ENTRY = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+include = '''
+(
+    \.py$
+    | invenio.cfg
+)
+'''

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -52,6 +52,7 @@ if [[ ${keep_services} -eq 0 ]]; then
 	trap cleanup EXIT
 fi
 
+python -m black --check .
 #python -m check_manifest
 #python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch} --mq ${MQ:-redis} --env)"

--- a/site/setup.cfg
+++ b/site/setup.cfg
@@ -1,4 +1,3 @@
-
 [metadata]
 name = ultraviolet
 

--- a/site/ultraviolet/generators.py
+++ b/site/ultraviolet/generators.py
@@ -1,9 +1,9 @@
-from flask_login import current_user
 from flask_principal import RoleNeed
-from invenio_access.permissions import authenticated_user, superuser_access, system_identity
+from invenio_access.permissions import (
+    superuser_access,
+)
 from invenio_records_permissions.generators import Generator
 from invenio_search.engine import dsl
-
 
 
 class AdminSuperUser(Generator):
@@ -20,7 +20,7 @@ class AdminSuperUser(Generator):
     def query_filter(self, identity=None, **kwargs):
         """Filters for current identity as super user."""
         if superuser_access in identity.provides:
-            return dsl.Q('match_all')
+            return dsl.Q("match_all")
         else:
             return []
 

--- a/site/ultraviolet/geoserver/describe_feature_type.py
+++ b/site/ultraviolet/geoserver/describe_feature_type.py
@@ -1,9 +1,8 @@
 import urllib
 
+import requests
 from flask import request, Response
 from flask.views import MethodView
-
-import requests
 
 
 class DescribeFeatureType(MethodView):
@@ -11,17 +10,19 @@ class DescribeFeatureType(MethodView):
 
     def post(self):
         """Pass DescribeFeatureType requests to GeoServer and hand back results."""
-        url = request.form.get('url', default=None)
-        layers = request.form.get('layers', default=None)
+        url = request.form.get("url", default=None)
+        layers = request.form.get("layers", default=None)
 
-        query_string = urllib.parse.urlencode({
-            "outputFormat": "application/json",
-            "request": "DescribeFeatureType",
-            "service": "WFS",
-            "typeName": layers,
-            "version": "1.1.0",
-        })
+        query_string = urllib.parse.urlencode(
+            {
+                "outputFormat": "application/json",
+                "request": "DescribeFeatureType",
+                "service": "WFS",
+                "typeName": layers,
+                "version": "1.1.0",
+            }
+        )
 
         response = requests.get("{0}?{1}".format(url, query_string))
 
-        return Response(response.text, mimetype='application/json')
+        return Response(response.text, mimetype="application/json")

--- a/site/ultraviolet/geoserver/describe_layer.py
+++ b/site/ultraviolet/geoserver/describe_layer.py
@@ -10,18 +10,20 @@ class DescribeLayer(MethodView):
 
     def post(self):
         """Pass DescribeLayer requests to GeoServer and hand back results."""
-        url = request.form.get('url', default=None)
-        layers = request.form.get('layers', default=None)
+        url = request.form.get("url", default=None)
+        layers = request.form.get("layers", default=None)
 
-        query_string = urllib.parse.urlencode({
-            "outputFormat": "application/json",
-            "exceptions": "application/json",
-            "request": "DescribeLayer",
-            "service": "WMS",
-            "layers": layers,
-            "version": "1.1.1",
-        })
+        query_string = urllib.parse.urlencode(
+            {
+                "outputFormat": "application/json",
+                "exceptions": "application/json",
+                "request": "DescribeLayer",
+                "service": "WMS",
+                "layers": layers,
+                "version": "1.1.1",
+            }
+        )
 
         response = requests.get("{0}?{1}".format(url, query_string))
 
-        return Response(response.text, mimetype='application/json')
+        return Response(response.text, mimetype="application/json")

--- a/site/ultraviolet/geoserver/fields.py
+++ b/site/ultraviolet/geoserver/fields.py
@@ -1,6 +1,7 @@
 from invenio_records_resources.services.custom_fields import BaseListCF
 from marshmallow import fields
 from marshmallow_utils.fields import SanitizedUnicode
+
 from ultraviolet.geoserver.validate import LayerValidator, BoundsValidator
 
 
@@ -12,12 +13,8 @@ class GeoServerCF(BaseListCF):
         field_args = dict(
             dict(
                 nested=dict(
-                    layer=SanitizedUnicode(
-                        validate=LayerValidator(server=server)
-                    ),
-                    bounds=SanitizedUnicode(
-                        validate=BoundsValidator()
-                    ),
+                    layer=SanitizedUnicode(validate=LayerValidator(server=server)),
+                    bounds=SanitizedUnicode(validate=BoundsValidator()),
                     has_wms=fields.Boolean(),
                     has_wfs=fields.Boolean(),
                 )
@@ -37,17 +34,9 @@ class GeoServerCF(BaseListCF):
         """Return the mapping."""
         return {
             "properties": {
-                "layer": {
-                    "type": "text"
-                },
-                "has_wms": {
-                    "type": "boolean"
-                },
-                "has_wfs": {
-                    "type": "boolean"
-                },
-                "bounds": {
-                    "type": "text"
-                },
+                "layer": {"type": "text"},
+                "has_wms": {"type": "boolean"},
+                "has_wfs": {"type": "boolean"},
+                "bounds": {"type": "text"},
             }
         }

--- a/site/ultraviolet/geoserver/get_feature_info.py
+++ b/site/ultraviolet/geoserver/get_feature_info.py
@@ -1,9 +1,8 @@
 import urllib
 
+import requests
 from flask import request, Response
 from flask.views import MethodView
-
-import requests
 
 
 class GetFeatureInfo(MethodView):
@@ -13,23 +12,25 @@ class GetFeatureInfo(MethodView):
         """Pass GetFeatureInfo requests to GeoServer and hand back results."""
         data = request.get_json()
 
-        url = data.get('url', None)
-        query_string = urllib.parse.urlencode({
-            "service": "WMS",
-            "version": "1.1.1",
-            "request": "GetFeatureInfo",
-            "layers": data.get('layers', None),
-            "query_layers": data.get('layers', None),
-            "bbox": data.get('bbox', None),
-            "width": data.get('width', None),
-            "height": data.get('height', None),
-            "x": data.get('x', None),
-            "y": data.get('y', None),
-            "srs": "EPSG:4326",
-            "info_format": "application/json",
-            "styles": ""
-        })
+        url = data.get("url", None)
+        query_string = urllib.parse.urlencode(
+            {
+                "service": "WMS",
+                "version": "1.1.1",
+                "request": "GetFeatureInfo",
+                "layers": data.get("layers", None),
+                "query_layers": data.get("layers", None),
+                "bbox": data.get("bbox", None),
+                "width": data.get("width", None),
+                "height": data.get("height", None),
+                "x": data.get("x", None),
+                "y": data.get("y", None),
+                "srs": "EPSG:4326",
+                "info_format": "application/json",
+                "styles": "",
+            }
+        )
 
         response = requests.get("{0}?{1}".format(url, query_string))
 
-        return Response(response.text, mimetype='application/json')
+        return Response(response.text, mimetype="application/json")

--- a/site/ultraviolet/geoserver/validate.py
+++ b/site/ultraviolet/geoserver/validate.py
@@ -14,7 +14,10 @@ _T = typing.TypeVar("_T")
 
 class BoundsValidator(Validator):
     def __call__(self, value: _T) -> _T:
-        if re.match(r"ENVELOPE\((-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)\)", value):
+        if re.match(
+            r"ENVELOPE\((-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)\)",
+            value,
+        ):
             return value
         else:
             raise ValidationError("Invalid bounds value")
@@ -43,14 +46,16 @@ class LayerValidator(Validator):
         errors = []
 
         url = "{0}/wms".format(self.server)
-        query_string = urllib.parse.urlencode({
-            "service": "WMS",
-            "version": "1.1.1",
-            "request": "DescribeLayer",
-            "layers": value,
-            "outputFormat": "application/json",
-            "exceptions": "application/json",
-        })
+        query_string = urllib.parse.urlencode(
+            {
+                "service": "WMS",
+                "version": "1.1.1",
+                "request": "DescribeLayer",
+                "layers": value,
+                "outputFormat": "application/json",
+                "exceptions": "application/json",
+            }
+        )
 
         full_url = "{0}?{1}".format(url, query_string)
         response = requests.get(full_url)
@@ -60,14 +65,16 @@ class LayerValidator(Validator):
             errors.append("Can't find WMS layer named {0}.".format(value))
 
         url = "{0}/wfs".format(self.server)
-        query_string = urllib.parse.urlencode({
-            "service": "WFS",
-            "version": "2.0.0",
-            "request": "DescribeFeatureType",
-            "typename": value,
-            "outputFormat": "application/json",
-            "exceptions": "application/json",
-        })
+        query_string = urllib.parse.urlencode(
+            {
+                "service": "WFS",
+                "version": "2.0.0",
+                "request": "DescribeFeatureType",
+                "typename": value,
+                "outputFormat": "application/json",
+                "exceptions": "application/json",
+            }
+        )
 
         full_url = "{0}?{1}".format(url, query_string)
         response = requests.get(full_url)
@@ -77,6 +84,10 @@ class LayerValidator(Validator):
             errors.append("Can't find WFS layer named {0}.".format(value))
 
         if len(errors) > 0:
-            raise ValidationError("Neither a WMS or WFS layer named {0} exists on {1} ".format(value, self.server))
+            raise ValidationError(
+                "Neither a WMS or WFS layer named {0} exists on {1} ".format(
+                    value, self.server
+                )
+            )
 
         return value

--- a/site/ultraviolet/policies.py
+++ b/site/ultraviolet/policies.py
@@ -1,8 +1,20 @@
 from flask import current_app
 from flask_principal import Permission, RoleNeed
 from invenio_rdm_records.services import RDMRecordPermissionPolicy
-from invenio_rdm_records.services.generators import SecretLinks, RecordCommunitiesAction, RecordOwners, AccessGrant, IfRestricted, ResourceAccessToken
-from invenio_records_permissions.generators import SystemProcess, AuthenticatedUser, AnyUser, Disable
+from invenio_rdm_records.services.generators import (
+    SecretLinks,
+    RecordCommunitiesAction,
+    RecordOwners,
+    AccessGrant,
+    IfRestricted,
+    ResourceAccessToken,
+)
+from invenio_records_permissions.generators import (
+    SystemProcess,
+    AuthenticatedUser,
+    AnyUser,
+    Disable,
+)
 
 from .generators import AdminSuperUser, Depositor, Curator, Viewer
 
@@ -15,18 +27,36 @@ class UltraVioletPermissionPolicy(RDMRecordPermissionPolicy):
     """
 
     NEED_LABEL_TO_ACTION = {
-        'bucket-update': 'update_files',
-        'bucket-read': 'read_files',
-        'object-read': 'read_files',
+        "bucket-update": "update_files",
+        "bucket-read": "read_files",
+        "object-read": "read_files",
     }
 
     #
     # High-level permissions (used by low-level)
     #
-    can_manage = [ RecordOwners(),Viewer(), SystemProcess(), AccessGrant("manage"), AdminSuperUser(), Depositor(), RecordCommunitiesAction("manage")]
-    can_curate = can_manage + [SecretLinks("edit"), AccessGrant("edit"),Curator(),RecordCommunitiesAction("curate")]
-    can_preview = can_manage + [SecretLinks("preview"), AccessGrant("view"),Curator()]
-    can_view = can_manage + [SecretLinks("view"),AccessGrant("view"), RecordCommunitiesAction("view"), Viewer()]
+    can_manage = [
+        RecordOwners(),
+        Viewer(),
+        SystemProcess(),
+        AccessGrant("manage"),
+        AdminSuperUser(),
+        Depositor(),
+        RecordCommunitiesAction("manage"),
+    ]
+    can_curate = can_manage + [
+        SecretLinks("edit"),
+        AccessGrant("edit"),
+        Curator(),
+        RecordCommunitiesAction("curate"),
+    ]
+    can_preview = can_manage + [SecretLinks("preview"), AccessGrant("view"), Curator()]
+    can_view = can_manage + [
+        SecretLinks("view"),
+        AccessGrant("view"),
+        RecordCommunitiesAction("view"),
+        Viewer(),
+    ]
 
     can_authenticated = [AuthenticatedUser(), SystemProcess()]
     can_all = [AnyUser(), SystemProcess()]
@@ -36,7 +66,7 @@ class UltraVioletPermissionPolicy(RDMRecordPermissionPolicy):
     #
     # Allow submitting new record
     can_create = can_manage
-     # Allow reading metadata of a record
+    # Allow reading metadata of a record
     can_read = [
         IfRestricted("record", then_=can_view, else_=can_all),
     ]

--- a/site/ultraviolet/views.py
+++ b/site/ultraviolet/views.py
@@ -6,6 +6,7 @@ from .geoserver.describe_feature_type import DescribeFeatureType
 from .geoserver.describe_layer import DescribeLayer
 from .geoserver.get_feature_info import GetFeatureInfo
 
+
 #
 # Registration
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
@@ -39,31 +36,31 @@ def app_config(app_config):
     app_config["SERVER_NAME"] = "127.0.0.1"
     app_config["MAX_FILE_SIZE"] = 50
     app_config["REST_CSRF_ENABLED"] = False
-    app_config['DATACITE_ENABLED'] = True
-    app_config['DATACITE_PREFIX'] = "10.1234"
+    app_config["DATACITE_ENABLED"] = True
+    app_config["DATACITE_PREFIX"] = "10.1234"
     app_config["APP_DEFAULT_SECURE_HEADERS"] = {
-        'content_security_policy': {
-            'default-src': [
+        "content_security_policy": {
+            "default-src": [
                 "'self'",
-                'data:',  # for fonts
+                "data:",  # for fonts
                 "'unsafe-inline'",  # for inline scripts and styles
                 "blob:",  # for pdf preview
                 # Add your own policies here (e.g. analytics)
             ],
         },
-        'content_security_policy_report_only': False,
-        'content_security_policy_report_uri': None,
-        'force_file_save': False,
-        'force_https': False,
-        'force_https_permanent': False,
-        'frame_options': 'sameorigin',
-        'frame_options_allow_from': None,
-        'session_cookie_http_only': True,
-        'session_cookie_secure': True,
-        'strict_transport_security': True,
-        'strict_transport_security_include_subdomains': True,
-        'strict_transport_security_max_age': 31556926,  # One year in seconds
-        'strict_transport_security_preload': False,
+        "content_security_policy_report_only": False,
+        "content_security_policy_report_uri": None,
+        "force_file_save": False,
+        "force_https": False,
+        "force_https_permanent": False,
+        "frame_options": "sameorigin",
+        "frame_options_allow_from": None,
+        "session_cookie_http_only": True,
+        "session_cookie_secure": True,
+        "strict_transport_security": True,
+        "strict_transport_security_include_subdomains": True,
+        "strict_transport_security_max_age": 31556926,  # One year in seconds
+        "strict_transport_security_preload": False,
     }
     return app_config
 
@@ -327,7 +324,7 @@ def geospatial_record(minimal_record):
             "bounds": "ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)",
             "has_wms": True,
             "has_wfs": True,
-        }
+        },
     }
 
     return minimal_record
@@ -383,13 +380,15 @@ def roles(app, db):
 
 @pytest.fixture(scope="module")
 def geospatial_resource_type_type(app):
-    """ Geospatial Resource Type type."""
-    return vocabulary_service.create_type(system_identity, "geospatialresourcetypes", "grt")
+    """Geospatial Resource Type type."""
+    return vocabulary_service.create_type(
+        system_identity, "geospatialresourcetypes", "grt"
+    )
 
 
 @pytest.fixture(scope="module")
 def geospatial_resource_type_v(app, geospatial_resource_type_type):
-    """ Geospatial Resource Type record."""
+    """Geospatial Resource Type record."""
     vocab = vocabulary_service.create(
         system_identity,
         {
@@ -398,7 +397,7 @@ def geospatial_resource_type_v(app, geospatial_resource_type_type):
                 "en": "LiDAR",
             },
             "type": "geospatialresourcetypes",
-        }
+        },
     )
 
     Vocabulary.index.refresh()
@@ -711,8 +710,8 @@ def licenses_v(app, licenses):
             "tags": ["recommended", "all"],
             "description": {
                 "en": "The Creative Commons Attribution license allows"
-                      " re-distribution and re-use of a licensed work on"
-                      " the condition that the creator is appropriately credited."
+                " re-distribution and re-use of a licensed work on"
+                " the condition that the creator is appropriately credited."
             },
             "type": "licenses",
         },
@@ -723,7 +722,10 @@ def licenses_v(app, licenses):
     return vocab
 
 
-from invenio_vocabularies.contrib.affiliations import AffiliationsService, AffiliationsServiceConfig
+from invenio_vocabularies.contrib.affiliations import (
+    AffiliationsService,
+    AffiliationsServiceConfig,
+)
 
 
 @pytest.fixture(scope="module")
@@ -731,7 +733,9 @@ def affiliations_v(app):
     """Affiliation vocabulary record."""
 
     if "affiliations" not in current_service_registry._services:
-        service = AffiliationsService(config=AffiliationsServiceConfig())  # Create an instance
+        service = AffiliationsService(
+            config=AffiliationsServiceConfig()
+        )  # Create an instance
         current_service_registry.register(service, "affiliations")
 
     affiliations_service = current_service_registry.get("affiliations")
@@ -753,7 +757,9 @@ def affiliations_v(app):
             ],
         },
     )
-    if not current_search_client.indices.exists(index="affiliations-affiliation-v2.0.0"):
+    if not current_search_client.indices.exists(
+        index="affiliations-affiliation-v2.0.0"
+    ):
         current_search_client.indices.create(index="affiliations-affiliation-v2.0.0")
 
     Affiliation.index.refresh()
@@ -927,25 +933,25 @@ RunningApp = namedtuple(
 
 @pytest.fixture
 def running_app(
-        app,
-        superuser_identity,
-        location,
-        cache,
-        resource_type_v,
-        subject_v,
-        languages_v,
-        affiliations_v,
-        title_type_v,
-        description_type_v,
-        date_type_v,
-        contributors_role_v,
-        relation_type_v,
-        licenses_v,
-        funders_v,
-        awards_v,
-        creatorsroles_v,
-        removal_reasons_v,
-        geospatial_resource_type_v,
+    app,
+    superuser_identity,
+    location,
+    cache,
+    resource_type_v,
+    subject_v,
+    languages_v,
+    affiliations_v,
+    title_type_v,
+    description_type_v,
+    date_type_v,
+    contributors_role_v,
+    relation_type_v,
+    licenses_v,
+    funders_v,
+    awards_v,
+    creatorsroles_v,
+    removal_reasons_v,
+    geospatial_resource_type_v,
 ):
     """This fixture provides an app with the typically needed db data loaded.
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # invenio-nyu is free software; you can redistribute it and/or modify it
@@ -12,8 +9,8 @@
 
 """Pytest configuration."""
 
-from invenio_app.factory import create_app as create_ui_api
 import pytest
+from invenio_app.factory import create_app as create_ui_api
 
 
 @pytest.fixture(scope="module")

--- a/tests/e2e/test_e2e_communities.py
+++ b/tests/e2e/test_e2e_communities.py
@@ -7,7 +7,6 @@
 """E2E test of Communities"""
 
 import os
-import time
 
 import pytest
 from flask import url_for
@@ -20,23 +19,28 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 
-@pytest.mark.skipif(os.getenv('E2E', 'no') != 'yes',
-                    reason="Skipping E2E tests because E2E environment variable is not set")
-def test_user_cannot_create_community(app, live_server,
-                                      resource_type_v,
-                                      subject_v,
-                                      languages_v,
-                                      affiliations_v,
-                                      title_type_v,
-                                      description_type_v,
-                                      date_type_v,
-                                      contributors_role_v,
-                                      relation_type_v,
-                                      licenses_v,
-                                      funders_v,
-                                      awards_v,
-                                      creatorsroles_v,
-                                      browser):
+@pytest.mark.skipif(
+    os.getenv("E2E", "no") != "yes",
+    reason="Skipping E2E tests because E2E environment variable is not set",
+)
+def test_user_cannot_create_community(
+    app,
+    live_server,
+    resource_type_v,
+    subject_v,
+    languages_v,
+    affiliations_v,
+    title_type_v,
+    description_type_v,
+    date_type_v,
+    contributors_role_v,
+    relation_type_v,
+    licenses_v,
+    funders_v,
+    awards_v,
+    creatorsroles_v,
+    browser,
+):
     email = "TEST@test.org"
     password = "123456"
 
@@ -54,13 +58,14 @@ def test_user_cannot_create_community(app, live_server,
     browser.set_window_size(1920, 3980)
 
     # Log in
-    browser.get(url_for("invenio_app_rdm_records.deposit_create", _external=True))
+    browser.get(url_for("security.login", _external=True))
     browser.find_element(By.NAME, "email").send_keys(email)
     browser.find_element(By.NAME, "password").send_keys(password)
     submit_button = WebDriverWait(browser, 10).until(
-        EC.element_to_be_clickable((By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button"))
+        EC.element_to_be_clickable(
+            (By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button")
+        )
     )
-
     submit_button.click()
 
     browser.get(url_for("invenio_communities.communities_frontpage", _external=True))

--- a/tests/e2e/test_e2e_deposit_form.py
+++ b/tests/e2e/test_e2e_deposit_form.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
@@ -10,7 +7,6 @@
 """View tests of the front page."""
 
 import os
-import time
 
 import pytest
 from flask import url_for
@@ -22,25 +18,29 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 
-# # create user on the fly - can login
-@pytest.mark.skipif(os.getenv('E2E', 'no') != 'yes',
-                    reason="Skipping E2E tests because E2E environment variable is not set")
-def test_element_not_in_deposit_form1(app, live_server,
-                                      resource_type_v,
-                                      subject_v,
-                                      languages_v,
-                                      affiliations_v,
-                                      title_type_v,
-                                      description_type_v,
-                                      date_type_v,
-                                      contributors_role_v,
-                                      relation_type_v,
-                                      licenses_v,
-                                      funders_v,
-                                      awards_v,
-                                      creatorsroles_v,
-                                      browser):
-    """Test for hidding References field on deposit form """
+@pytest.mark.skipif(
+    os.getenv("E2E", "no") != "yes",
+    reason="Skipping E2E tests because E2E environment variable is not set",
+)
+def test_element_not_in_deposit_form1(
+    app,
+    live_server,
+    resource_type_v,
+    subject_v,
+    languages_v,
+    affiliations_v,
+    title_type_v,
+    description_type_v,
+    date_type_v,
+    contributors_role_v,
+    relation_type_v,
+    licenses_v,
+    funders_v,
+    awards_v,
+    creatorsroles_v,
+    browser,
+):
+    """Test for hidding References field on deposit form"""
     email = "TEST@test.org"
     password = "123456"
 
@@ -56,13 +56,19 @@ def test_element_not_in_deposit_form1(app, live_server,
         datastore.commit()
 
     browser.set_window_size(1920, 3980)
+
+    # Log in
     browser.get(url_for("invenio_app_rdm_records.deposit_create", _external=True))
     browser.find_element(By.NAME, "email").send_keys(email)
     browser.find_element(By.NAME, "password").send_keys(password)
     submit_button = WebDriverWait(browser, 10).until(
-        EC.element_to_be_clickable((By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button"))
+        EC.element_to_be_clickable(
+            (By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button")
+        )
     )
     submit_button.click()
-    page_source = browser.page_source
+
     # Assert that the text "References" is not present in the HTML
-    assert "Reference string" not in page_source, "'References' field is present in the HTML, but it should not be."
+    assert (
+        "Reference string" not in browser.page_source
+    ), "'References' field is present in the HTML, but it should not be."

--- a/tests/e2e/test_e2e_front_page.py
+++ b/tests/e2e/test_e2e_front_page.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
@@ -21,8 +18,10 @@ from selenium.webdriver.common.by import By
 multiprocessing.set_start_method("fork")
 
 
-@pytest.mark.skipif(os.getenv('E2E', 'no') != 'yes',
-                    reason="Skipping E2E tests because E2E environment variable is not set")
+@pytest.mark.skipif(
+    os.getenv("E2E", "no") != "yes",
+    reason="Skipping E2E tests because E2E environment variable is not set",
+)
 def test_frontpage(live_server, browser):
     """Test retrieval of front page."""
     browser.get(url_for("invenio_app_rdm.index", _external=True))

--- a/tests/e2e/test_e2e_profile_menu.py
+++ b/tests/e2e/test_e2e_profile_menu.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
@@ -22,8 +19,10 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 
-@pytest.mark.skipif(os.getenv('E2E', 'no') != 'yes',
-                    reason="Skipping E2E tests because E2E environment variable is not set")
+@pytest.mark.skipif(
+    os.getenv("E2E", "no") != "yes",
+    reason="Skipping E2E tests because E2E environment variable is not set",
+)
 def test_admins_see_administration_item(app, live_server, browser):
     """Test for Profile menu Administration entry"""
     email = "foobar@test.org"
@@ -46,7 +45,9 @@ def test_admins_see_administration_item(app, live_server, browser):
     browser.find_element(By.NAME, "email").send_keys(email)
     browser.find_element(By.NAME, "password").send_keys(password)
     submit_button = WebDriverWait(browser, 10).until(
-        EC.element_to_be_clickable((By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button"))
+        EC.element_to_be_clickable(
+            (By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button")
+        )
     )
     submit_button.click()
     time.sleep(2)
@@ -56,8 +57,10 @@ def test_admins_see_administration_item(app, live_server, browser):
     assert "Administration" in page_source
 
 
-@pytest.mark.skipif(os.getenv('E2E', 'no') != 'yes',
-                    reason="Skipping E2E tests because E2E environment variable is not set")
+@pytest.mark.skipif(
+    os.getenv("E2E", "no") != "yes",
+    reason="Skipping E2E tests because E2E environment variable is not set",
+)
 def test_regular_users_do_not_see_administration_item(app, live_server, browser):
     """Test for Profile menu Administration entry"""
     email = "foobarbaz@test.org"
@@ -72,7 +75,9 @@ def test_regular_users_do_not_see_administration_item(app, live_server, browser)
     browser.find_element(By.NAME, "email").send_keys(email)
     browser.find_element(By.NAME, "password").send_keys(password)
     submit_button = WebDriverWait(browser, 10).until(
-        EC.element_to_be_clickable((By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button"))
+        EC.element_to_be_clickable(
+            (By.CSS_SELECTOR, "button.ui.fluid.large.submit.primary.button")
+        )
     )
     submit_button.click()
     time.sleep(2)

--- a/tests/geoserver/test_validate.py
+++ b/tests/geoserver/test_validate.py
@@ -14,9 +14,9 @@ def valid_wms_response():
                 "layerName": "nyu_2451_41645",
                 "owsURL": "https://fake-geoserver.org/geoserver/sdr/wfs?",
                 "owsType": "WFS",
-                "typeName": "nyu_2451_41645"
+                "typeName": "nyu_2451_41645",
             }
-        ]
+        ],
     }
 
 
@@ -36,11 +36,11 @@ def valid_wfs_response():
                         "minOccurs": 0,
                         "nillable": True,
                         "type": "xsd:int",
-                        "localType": "int"
+                        "localType": "int",
                     }
-                ]
+                ],
             }
-        ]
+        ],
     }
 
 
@@ -52,9 +52,9 @@ def invalid_wms_response():
             {
                 "code": "LayerNotDefined",
                 "locator": "MapLayerInfoKvpParser",
-                "text": "sdr:foo_bar: no such layer on this server"
+                "text": "sdr:foo_bar: no such layer on this server",
             }
-        ]
+        ],
     }
 
 
@@ -66,9 +66,9 @@ def invalid_wfs_response():
             {
                 "code": "InvalidParameterValue",
                 "locator": "DescribeFeatureType",
-                "text": "Could not find type: sdr:foo_bar"
+                "text": "Could not find type: sdr:foo_bar",
             }
-        ]
+        ],
     }
 
 
@@ -86,16 +86,16 @@ def test_layer_empty():
 def test_layer_valid(valid_wms_response, valid_wfs_response):
     responses.add(
         method=responses.GET,
-        url='https://fake-geoserver.org/geoserver/sdr/wms',
+        url="https://fake-geoserver.org/geoserver/sdr/wms",
         json=valid_wms_response,
-        status=200
+        status=200,
     )
 
     responses.add(
         method=responses.GET,
-        url='https://fake-geoserver.org/geoserver/sdr/wfs',
+        url="https://fake-geoserver.org/geoserver/sdr/wfs",
         json=valid_wfs_response,
-        status=200
+        status=200,
     )
 
     validator = LayerValidator(server="https://fake-geoserver.org/geoserver/sdr")
@@ -106,16 +106,16 @@ def test_layer_valid(valid_wms_response, valid_wfs_response):
 def test_layer_invalid(invalid_wms_response, invalid_wfs_response):
     responses.add(
         method=responses.GET,
-        url='https://fake-geoserver.org/geoserver/sdr/wms',
+        url="https://fake-geoserver.org/geoserver/sdr/wms",
         json=invalid_wms_response,
-        status=200
+        status=200,
     )
 
     responses.add(
         method=responses.GET,
-        url='https://fake-geoserver.org/geoserver/sdr/wfs',
+        url="https://fake-geoserver.org/geoserver/sdr/wfs",
         json=invalid_wfs_response,
-        status=400
+        status=400,
     )
 
     validator = LayerValidator(server="https://fake-geoserver.org/geoserver/sdr")
@@ -128,16 +128,16 @@ def test_layer_invalid(invalid_wms_response, invalid_wfs_response):
 def test_layer_half_valid(invalid_wms_response, valid_wfs_response):
     responses.add(
         method=responses.GET,
-        url='https://fake-geoserver.org/geoserver/sdr/wms',
+        url="https://fake-geoserver.org/geoserver/sdr/wms",
         json=invalid_wms_response,
-        status=200
+        status=200,
     )
 
     responses.add(
         method=responses.GET,
-        url='https://fake-geoserver.org/geoserver/sdr/wfs',
+        url="https://fake-geoserver.org/geoserver/sdr/wfs",
         json=valid_wfs_response,
-        status=400
+        status=400,
     )
 
     validator = LayerValidator(server="https://fake-geoserver.org/geoserver/sdr")
@@ -149,19 +149,24 @@ def test_layer_half_valid(invalid_wms_response, valid_wfs_response):
 def test_bounds_valid_decimals():
     validator = BoundsValidator()
 
-    assert validator(
-        "ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)") == "ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)"
+    assert (
+        validator(
+            "ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)"
+        )
+        == "ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)"
+    )
 
 
 def test_bounds_valid_integers():
     validator = BoundsValidator()
 
-    assert validator(
-        "ENVELOPE(-74, -73, 40, 40)") == "ENVELOPE(-74, -73, 40, 40)"
+    assert validator("ENVELOPE(-74, -73, 40, 40)") == "ENVELOPE(-74, -73, 40, 40)"
 
 
 def test_bounds_invalid():
     validator = BoundsValidator()
 
     with pytest.raises(ValidationError):
-        validator("ENVELOPE(-74.2556640887564 -73.700009054899 40.9157739339836 40.4960925239255)")
+        validator(
+            "ENVELOPE(-74.2556640887564 -73.700009054899 40.9157739339836 40.4960925239255)"
+        )

--- a/tests/permissions/test_generators.py
+++ b/tests/permissions/test_generators.py
@@ -1,5 +1,6 @@
 from flask_principal import RoleNeed
 from invenio_access import superuser_access
+
 from ultraviolet.generators import AdminSuperUser, Depositor, Curator, Viewer
 
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -1,15 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 # Tests  to check configuration settings
-import os
 import sys
 
 from invenio_app.factory import create_app
@@ -26,8 +22,8 @@ def test_var_assigned(monkeypatch):
     monkeypatch.setenv("SITE_UI_URL", app_host)
     monkeypatch.setenv("SITE_API_URL", app_host + "/api")
     monkeypatch.setenv("APP_ENVIRONMENT", "global")
-    monkeypatch.setenv("COLLECT_STATIC_ROOT","/opt/static")
-    monkeypatch.setenv("DATACITE_ENABLED","true")
+    monkeypatch.setenv("COLLECT_STATIC_ROOT", "/opt/static")
+    monkeypatch.setenv("DATACITE_ENABLED", "true")
 
     """Create app with configurations passed above"""
     app = create_app()
@@ -49,5 +45,8 @@ def test_var_noassigned():
     assert app.config.get("SITE_API_URL") == "https://127.0.0.1:5000/api"
     assert app.config.get("APP_ENVIRONMENT") == "local"
     assert app.config.get("COLLECT_STATIC_ROOT") == sys.prefix + "/var/instance/static"
-    assert app.config.get("RDM_RECORDS_USER_FIXTURE_PASSWORDS")['adminUV@test.com'] == "adminUV"
+    assert (
+        app.config.get("RDM_RECORDS_USER_FIXTURE_PASSWORDS")["adminUV@test.com"]
+        == "adminUV"
+    )
     assert app.config.get("DATACITE_ENABLED") == False

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it

--- a/tests/ui/test_deposit_form.py
+++ b/tests/ui/test_deposit_form.py
@@ -1,25 +1,22 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 """View tests of the front page."""
 
-
 from flask import url_for
-from flask_security import login_user
 from invenio_accounts.testutils import login_user_via_session
+
 
 def test_reference_not_in_deposit_form(services, client, app, admin_user):
     """Test that verifies References field is not present in the deposit form."""
-    
-    uploads_url = url_for("invenio_app_rdm_records.deposit_create", _external=True) 
+
+    uploads_url = url_for("invenio_app_rdm_records.deposit_create", _external=True)
     login_user_via_session(client, email=admin_user.email)
     response = client.get(uploads_url)
     assert admin_user.email in response.data.decode()
-    assert "Reference string" not in response.data.decode(), "'References' field is present in the HTML, but it should not be."
-
+    assert (
+        "Reference string" not in response.data.decode()
+    ), "'References' field is present in the HTML, but it should not be."

--- a/tests/ui/test_files_page_download.py
+++ b/tests/ui/test_files_page_download.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
@@ -10,16 +7,19 @@
 """View tests of the front page."""
 
 from io import BytesIO
+
 from invenio_access.permissions import system_identity
 from invenio_rdm_records.proxies import current_rdm_records_service
 
 
-def test_one_small_file(minimal_record, client_with_login, services, app, db, register_file_service):
+def test_one_small_file(
+    minimal_record, client_with_login, services, app, db, register_file_service
+):
     """
     Test files page for small file in the application.
     The Download button, Download all button, and file name download link should present.
     """
-    
+
     service = current_rdm_records_service
 
     data = minimal_record.copy()
@@ -39,16 +39,20 @@ def test_one_small_file(minimal_record, client_with_login, services, app, db, re
 
     # Publish
     record = service.publish(system_identity, draft.id)
-    record_view = client_with_login.get("/records/" + record['id']).data
+    record_view = client_with_login.get("/records/" + record["id"]).data
     html = record_view.decode("utf-8")
 
     # Download all button should present
     assert "Download all" in html
     # Downlaod button should present
-    expected_button_html = '<a role="button" class="ui compact mini button" href="/records/{}/files/test.pdf?download=1">'.format(record['id'])
+    expected_button_html = '<a role="button" class="ui compact mini button" href="/records/{}/files/test.pdf?download=1">'.format(
+        record["id"]
+    )
     assert expected_button_html in html
     # File name download link should present
-    expected_namelink_html = '<a class="wrap-long-link" href="/records/{}/files/test.pdf?download=1">test.pdf</a>'.format(record['id'])
+    expected_namelink_html = '<a class="wrap-long-link" href="/records/{}/files/test.pdf?download=1">test.pdf</a>'.format(
+        record["id"]
+    )
     assert expected_namelink_html in html
 
 
@@ -75,22 +79,26 @@ def test_one_large_file(services, minimal_record, client_with_login, app):
 
     # larger than config limit
     service.draft_files.set_file_content(
-        system_identity, draft.id, "test.pdf", BytesIO(b'1' * (10**6))
+        system_identity, draft.id, "test.pdf", BytesIO(b"1" * (10**6))
     )
     service.draft_files.commit_file(system_identity, draft.id, "test.pdf")
 
     # Publish
     record = service.publish(system_identity, draft.id)
-    record_view = client_with_login.get("/records/" + record['id']).data
+    record_view = client_with_login.get("/records/" + record["id"]).data
     html = record_view.decode("utf-8")
-    
+
     # Download all button should not present
     assert "Download all" not in html
     # Downlaod button should not present
-    expected_button_html = '<a role="button" class="ui compact mini button" href="/records/{}/files/test.pdf?download=1">'.format(record['id'])
+    expected_button_html = '<a role="button" class="ui compact mini button" href="/records/{}/files/test.pdf?download=1">'.format(
+        record["id"]
+    )
     assert expected_button_html not in html
     # File name download link should not present
-    expected_namelink_html = '<a class="wrap-long-link" href="/records/{}/files/test.pdf?download=1">test.pdf</a>'.format(record['id'])
+    expected_namelink_html = '<a class="wrap-long-link" href="/records/{}/files/test.pdf?download=1">test.pdf</a>'.format(
+        record["id"]
+    )
     assert expected_namelink_html not in html
 
     app.config["APP_RDM_RECORD_LANDING_PAGE_FAIR_SIGNPOSTING_LEVEL_1_ENABLED"] = True
@@ -118,37 +126,45 @@ def test_two_files(services, minimal_record, client_with_login, app):
     service.draft_files.init_files(
         system_identity, draft.id, data=[{"key": "small.pdf"}, {"key": "large.pdf"}]
     )
-    
+
     service.draft_files.set_file_content(
         system_identity, draft.id, "small.pdf", BytesIO(b"test file")
     )
     service.draft_files.commit_file(system_identity, draft.id, "small.pdf")
     # larger than config limit
     service.draft_files.set_file_content(
-        system_identity, draft.id, "large.pdf", BytesIO(b'1' * (10**6))
+        system_identity, draft.id, "large.pdf", BytesIO(b"1" * (10**6))
     )
     service.draft_files.commit_file(system_identity, draft.id, "large.pdf")
 
     # Publish
     record = service.publish(system_identity, draft.id)
-    record_view = client_with_login.get("/records/" + record['id']).data
+    record_view = client_with_login.get("/records/" + record["id"]).data
     html = record_view.decode("utf-8")
-    
+
     # Download all button show not present
     assert "Download all" not in html
 
     # Download button for small file should present
-    small_file_download_button_html = '<a role="button" class="ui compact mini button" href="/records/{}/files/small.pdf?download=1">'.format(record['id'])
+    small_file_download_button_html = '<a role="button" class="ui compact mini button" href="/records/{}/files/small.pdf?download=1">'.format(
+        record["id"]
+    )
     assert small_file_download_button_html in html
     # File name download link should present
-    expected_namelink_html = '<a class="wrap-long-link" href="/records/{}/files/small.pdf?download=1">small.pdf</a>'.format(record['id'])
+    expected_namelink_html = '<a class="wrap-long-link" href="/records/{}/files/small.pdf?download=1">small.pdf</a>'.format(
+        record["id"]
+    )
     assert expected_namelink_html in html
 
     # Download button for large file should not present
-    large_file_download_button_html = '<a role="button" class="ui compact mini button" href="/records/{}/files/large.pdf?download=1">'.format(record['id'])
+    large_file_download_button_html = '<a role="button" class="ui compact mini button" href="/records/{}/files/large.pdf?download=1">'.format(
+        record["id"]
+    )
     assert large_file_download_button_html not in html
     # File name download link should not present
-    expected_namelink_html = '<a class="wrap-long-link" href="/records/{}/files/large.pdf?download=1">large.pdf</a>'.format(record['id'])
+    expected_namelink_html = '<a class="wrap-long-link" href="/records/{}/files/large.pdf?download=1">large.pdf</a>'.format(
+        record["id"]
+    )
     assert expected_namelink_html not in html
 
     app.config["APP_RDM_RECORD_LANDING_PAGE_FAIR_SIGNPOSTING_LEVEL_1_ENABLED"] = True

--- a/tests/ui/test_front_view.py
+++ b/tests/ui/test_front_view.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
@@ -10,20 +7,19 @@
 """View tests of the front page."""
 
 
-def test_front_page(db,base_client):
+def test_front_page(db, base_client):
     # Depends on 'base_app' fixture
     front_view = base_client.get("/").data
     assert (
         "https://library.nyu.edu/departments/scholarly-communications-information-policy/"
         in front_view.decode("utf-8")
     )
-    assert (
-        "NYU Scholarly Communication and Information Policy"
-        in front_view.decode("utf-8")
+    assert "NYU Scholarly Communication and Information Policy" in front_view.decode(
+        "utf-8"
     )
 
 
-def test_header_menu_button(db,base_client):
+def test_header_menu_button(db, base_client):
     front_view = base_client.get("/").data
     assert "Browse" in front_view.decode("utf-8")
     assert "FAQs" in front_view.decode("utf-8")

--- a/tests/ui/test_map_view.py
+++ b/tests/ui/test_map_view.py
@@ -4,51 +4,71 @@ from invenio_access.permissions import system_identity
 def test_public_map_view_when_anonymous(services, geospatial_record, client):
     published_record = publish_draft(geospatial_record, services)
 
-    html = client.get("/records/" + published_record['id']).data.decode("utf-8")
+    html = client.get("/records/" + published_record["id"]).data.decode("utf-8")
 
     assert "Geospatial Data" in html
     assert "Web Services" in html
 
-    assert "data-preview=\"True\"" in html
-    assert "data-wms-url=\"https://maps-public.geo.nyu.edu/geoserver/sdr/wms\"" in html
-    assert "data-layer-name=\"sdr:nyu_2451_34156\"" in html
-    assert "data-bounds=\"ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)\"" in html
+    assert 'data-preview="True"' in html
+    assert 'data-wms-url="https://maps-public.geo.nyu.edu/geoserver/sdr/wms"' in html
+    assert 'data-layer-name="sdr:nyu_2451_34156"' in html
+    assert (
+        'data-bounds="ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)"'
+        in html
+    )
 
 
-def test_restricted_map_view_when_logged_in(services, restricted_geospatial_record, client_with_login, app):
+def test_restricted_map_view_when_logged_in(
+    services, restricted_geospatial_record, client_with_login, app
+):
     app.config["APP_RDM_RECORD_LANDING_PAGE_FAIR_SIGNPOSTING_LEVEL_1_ENABLED"] = False
 
     published_record = publish_draft(restricted_geospatial_record, services)
 
-    html = client_with_login.get("/records/" + published_record['id']).data.decode("utf-8")
+    html = client_with_login.get("/records/" + published_record["id"]).data.decode(
+        "utf-8"
+    )
 
     assert "Geospatial Data" in html
     assert "Web Services" in html
 
-    assert "data-preview=\"True\"" in html
-    assert "data-wms-url=\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\"" in html
-    assert "data-layer-name=\"sdr:nyu_2451_34156\"" in html
-    assert "data-bounds=\"ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)\"" in html
+    assert 'data-preview="True"' in html
+    assert (
+        'data-wms-url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms"' in html
+    )
+    assert 'data-layer-name="sdr:nyu_2451_34156"' in html
+    assert (
+        'data-bounds="ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)"'
+        in html
+    )
 
     assert "LiDAR" in html
 
     app.config["APP_RDM_RECORD_LANDING_PAGE_FAIR_SIGNPOSTING_LEVEL_1_ENABLED"] = True
 
 
-def test_restricted_map_view_when_anonymous(services, restricted_geospatial_record, client, app):
+def test_restricted_map_view_when_anonymous(
+    services, restricted_geospatial_record, client, app
+):
     app.config["APP_RDM_RECORD_LANDING_PAGE_FAIR_SIGNPOSTING_LEVEL_1_ENABLED"] = False
 
     published_record = publish_draft(restricted_geospatial_record, services)
 
-    html = client.get("/records/" + published_record['id']).data.decode("utf-8")
+    html = client.get("/records/" + published_record["id"]).data.decode("utf-8")
 
     assert "Geospatial Data" in html
-    assert "data-preview=\"False\"" in html
-    assert "data-bounds=\"ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)\"" in html
+    assert 'data-preview="False"' in html
+    assert (
+        'data-bounds="ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)"'
+        in html
+    )
 
     assert "Web Services" not in html
-    assert "data-wms-url=\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\"" not in html
-    assert "data-layer-name=\"sdr:nyu_2451_34156\"" not in html
+    assert (
+        'data-wms-url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms"'
+        not in html
+    )
+    assert 'data-layer-name="sdr:nyu_2451_34156"' not in html
 
     app.config["APP_RDM_RECORD_LANDING_PAGE_FAIR_SIGNPOSTING_LEVEL_1_ENABLED"] = True
 

--- a/tests/ui/test_meta_tags.py
+++ b/tests/ui/test_meta_tags.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
@@ -26,19 +23,40 @@ def test_meta_tags(full_record, services, client, app, db, admin_user):
     record = service.publish(system_identity, draft.id)
     recid = record["id"]
     with app.test_request_context():
-        record_url = url_for('invenio_app_rdm_records.record_detail', pid_value=recid)
+        record_url = url_for("invenio_app_rdm_records.record_detail", pid_value=recid)
 
     login_user_via_session(client, email=admin_user.email)
 
     response = client.get(record_url)
     html_content = response.data.decode()
 
-    assert '<meta name="citation_title" content="InvenioRDM" />' in html_content, "Missing citation_title tag"
-    assert '<meta name="description" content="A description with HTML tags" />' in html_content, "Missing description tag"
-    assert '<meta name="citation_author" content="Nielsen, Lars Holm" />' in html_content, "Missing author tag"
-    assert '<meta name="citation_publication_date" content="2020/09/01" />' in html_content, "Missing citation_publication_date tag"
-    assert '<meta name="citation_publisher" content="InvenioRDM" />' in html_content, "Missing citation_publisher tag"
-    assert '<meta name="citation_doi" content="10.1234/inveniordm.1234" />' in html_content, "Missing citation_doi tag"
-    assert '<meta name="citation_keywords" content="custom" />' in html_content, "Missing citation_keywords tag"
-    assert '<meta name="citation_abstract_html_url" content="https://127.0.0.1:5000/records/' in html_content, "Missing citation_abstract_html_url tag"
-    assert '<meta name="citation_contributor" content="Nielsen, Lars Holm" />' in html_content, "Missing contirbutor tag"
+    assert (
+        '<meta name="citation_title" content="InvenioRDM" />' in html_content
+    ), "Missing citation_title tag"
+    assert (
+        '<meta name="description" content="A description with HTML tags" />'
+        in html_content
+    ), "Missing description tag"
+    assert (
+        '<meta name="citation_author" content="Nielsen, Lars Holm" />' in html_content
+    ), "Missing author tag"
+    assert (
+        '<meta name="citation_publication_date" content="2020/09/01" />' in html_content
+    ), "Missing citation_publication_date tag"
+    assert (
+        '<meta name="citation_publisher" content="InvenioRDM" />' in html_content
+    ), "Missing citation_publisher tag"
+    assert (
+        '<meta name="citation_doi" content="10.1234/inveniordm.1234" />' in html_content
+    ), "Missing citation_doi tag"
+    assert (
+        '<meta name="citation_keywords" content="custom" />' in html_content
+    ), "Missing citation_keywords tag"
+    assert (
+        '<meta name="citation_abstract_html_url" content="https://127.0.0.1:5000/records/'
+        in html_content
+    ), "Missing citation_abstract_html_url tag"
+    assert (
+        '<meta name="citation_contributor" content="Nielsen, Lars Holm" />'
+        in html_content
+    ), "Missing contirbutor tag"

--- a/tests/ui/test_permissions.py
+++ b/tests/ui/test_permissions.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 """Tests for restricted file message on record page."""
+
 import pytest
 from invenio_access.permissions import system_identity
 from invenio_communities import current_communities
-from invenio_rdm_records.proxies import current_rdm_records_service, current_record_communities_service
+from invenio_rdm_records.proxies import (
+    current_rdm_records_service,
+    current_record_communities_service,
+)
 from invenio_search import current_search_client
 
 
@@ -29,15 +30,17 @@ def restricted_record():
         "metadata": {
             "publication_date": "2020-06-01",
             "resource_type": {"id": "image-photo"},
-            "creators": [{
-                "person_or_org": {
-                    "name": "Troy Inc.",
-                    "type": "organizational",
-                },
-            }],
+            "creators": [
+                {
+                    "person_or_org": {
+                        "name": "Troy Inc.",
+                        "type": "organizational",
+                    },
+                }
+            ],
             "publisher": "Acme Inc",
             "title": "A Romans story",
-        }
+        },
     }
 
 
@@ -47,46 +50,69 @@ def communities_index():
         current_search_client.indices.create(index="communities-communities-v2.0.0")
 
 
-def test_user_without_special_role_cannot_access_restricted_records(services, app, db, client_with_login,
-                                                                    restricted_record):
-    draft = current_rdm_records_service.create(system_identity, restricted_record.copy())
+def test_user_without_special_role_cannot_access_restricted_records(
+    services, app, db, client_with_login, restricted_record
+):
+    draft = current_rdm_records_service.create(
+        system_identity, restricted_record.copy()
+    )
     record = current_rdm_records_service.publish(system_identity, draft.id)
 
-    response = client_with_login.get("/api/records/" + record['id'], headers={
-        'content-type': 'application/octet-stream',
-        'accept': 'application/json'
-    })
+    response = client_with_login.get(
+        "/api/records/" + record["id"],
+        headers={
+            "content-type": "application/octet-stream",
+            "accept": "application/json",
+        },
+    )
 
     assert 403 == response.status_code
 
 
-def test_anonymous_user_cannot_access_restricted_records(services, app, db, base_client, restricted_record):
-    draft = current_rdm_records_service.create(system_identity, restricted_record.copy())
+def test_anonymous_user_cannot_access_restricted_records(
+    services, app, db, base_client, restricted_record
+):
+    draft = current_rdm_records_service.create(
+        system_identity, restricted_record.copy()
+    )
     record = current_rdm_records_service.publish(system_identity, draft.id)
 
-    response = base_client.get("/api/records/" + record['id'], headers={
-        'content-type': 'application/octet-stream',
-        'accept': 'application/json'
-    })
+    response = base_client.get(
+        "/api/records/" + record["id"],
+        headers={
+            "content-type": "application/octet-stream",
+            "accept": "application/json",
+        },
+    )
 
     assert 403 == response.status_code
 
 
-def test_user_with_nyu_role_can_access_restricted_records(services, app, client_with_nyu_login, restricted_record):
-    draft = current_rdm_records_service.create(system_identity, restricted_record.copy())
+def test_user_with_nyu_role_can_access_restricted_records(
+    services, app, client_with_nyu_login, restricted_record
+):
+    draft = current_rdm_records_service.create(
+        system_identity, restricted_record.copy()
+    )
     record = current_rdm_records_service.publish(system_identity, draft.id)
 
-    response = client_with_nyu_login.get("/api/records/" + record['id'], headers={
-        'content-type': 'application/octet-stream',
-        'accept': 'application/json'
-    })
+    response = client_with_nyu_login.get(
+        "/api/records/" + record["id"],
+        headers={
+            "content-type": "application/octet-stream",
+            "accept": "application/json",
+        },
+    )
 
     assert 200 == response.status_code
 
 
-def test_user_without_community_access_cannot_see_restricted_records(services, app, db, base_client, restricted_record,
-                                                                     communities_index):
-    draft = current_rdm_records_service.create(identity=system_identity, data=(restricted_record.copy()))
+def test_user_without_community_access_cannot_see_restricted_records(
+    services, app, db, base_client, restricted_record, communities_index
+):
+    draft = current_rdm_records_service.create(
+        identity=system_identity, data=(restricted_record.copy())
+    )
     record = current_rdm_records_service.publish(system_identity, draft.id)
 
     community = current_communities.service.create(
@@ -101,25 +127,36 @@ def test_user_without_community_access_cannot_see_restricted_records(services, a
             "metadata": {
                 "title": "Test Community",
             },
-        })
-
-    current_record_communities_service.add(
-        system_identity,
-        record["id"],
-        {"communities": [{"id": community.id}]}
+        },
     )
 
-    response = base_client.get("/api/records/" + record['id'], headers={
-        'content-type': 'application/octet-stream',
-        'accept': 'application/json'
-    })
+    current_record_communities_service.add(
+        system_identity, record["id"], {"communities": [{"id": community.id}]}
+    )
+
+    response = base_client.get(
+        "/api/records/" + record["id"],
+        headers={
+            "content-type": "application/octet-stream",
+            "accept": "application/json",
+        },
+    )
 
     assert 403 == response.status_code
 
 
-def test_user_with_community_access_can_see_restricted_records(services, app, db, client_with_basic_user, users,
-                                                               restricted_record, communities_index):
-    draft = current_rdm_records_service.create(identity=system_identity, data=(restricted_record.copy()))
+def test_user_with_community_access_can_see_restricted_records(
+    services,
+    app,
+    db,
+    client_with_basic_user,
+    users,
+    restricted_record,
+    communities_index,
+):
+    draft = current_rdm_records_service.create(
+        identity=system_identity, data=(restricted_record.copy())
+    )
     record = current_rdm_records_service.publish(system_identity, draft.id)
 
     community = current_communities.service.create(
@@ -134,26 +171,25 @@ def test_user_with_community_access_can_see_restricted_records(services, app, db
             "metadata": {
                 "title": "Test Community",
             },
-        })
+        },
+    )
 
     current_communities.service.members.add(
         system_identity,
         community.id,
-        {
-            "members": [{"type": "user", "id": str(users["user5"].id)}],
-            "role": "reader"
-        }
+        {"members": [{"type": "user", "id": str(users["user5"].id)}], "role": "reader"},
     )
 
     current_record_communities_service.add(
-        system_identity,
-        record["id"],
-        {"communities": [{"id": community.id}]}
+        system_identity, record["id"], {"communities": [{"id": community.id}]}
     )
 
-    response = client_with_basic_user.get("/api/records/" + record['id'], headers={
-        'content-type': 'application/octet-stream',
-        'accept': 'application/json'
-    })
+    response = client_with_basic_user.get(
+        "/api/records/" + record["id"],
+        headers={
+            "content-type": "application/octet-stream",
+            "accept": "application/json",
+        },
+    )
 
     assert 200 == response.status_code

--- a/tests/ui/test_restricted_file_msg.py
+++ b/tests/ui/test_restricted_file_msg.py
@@ -1,25 +1,24 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 """Tests for restricted file message on record page."""
 
-
 from io import BytesIO
+
 from invenio_access.permissions import system_identity
 from invenio_rdm_records.proxies import current_rdm_records_service
 
 
-def test_restricted_file_message(minimal_record, services, app, db, register_file_service, client):
+def test_restricted_file_message(
+    minimal_record, services, app, db, register_file_service, client
+):
     """
     Test restricted file message on record page.
     """
-    
+
     service = current_rdm_records_service
 
     data = minimal_record.copy()
@@ -42,9 +41,12 @@ def test_restricted_file_message(minimal_record, services, app, db, register_fil
 
     # Publish
     record = service.publish(system_identity, draft.id)
-    record_view = client.get("/records/" + record['id']).data
+    record_view = client.get("/records/" + record["id"]).data
     html = record_view.decode("utf-8")
     print(html)
 
     # Restricted file message should present
-    assert "The files associated with this metadata record are restricted to members of the NYU community." in html
+    assert (
+        "The files associated with this metadata record are restricted to members of the NYU community."
+        in html
+    )

--- a/tests/ui/test_rm_account_elements.py
+++ b/tests/ui/test_rm_account_elements.py
@@ -7,31 +7,36 @@
 """Test account pages elements: Change Password (removed), Developer Applications of Applications (removed)."""
 
 from flask import url_for
-from flask_security import login_user
 from invenio_accounts.testutils import login_user_via_session
+
 
 def test_change_password_not_in_profile_form(services, client, app, admin_user):
     """Test that verifies Change Password field is not present in the profile form."""
-    
-    uploads_url = url_for("invenio_userprofiles.profile", _external=True) 
+
+    uploads_url = url_for("invenio_userprofiles.profile", _external=True)
     login_user_via_session(client, email=admin_user.email)
     response = client.get(uploads_url)
     html = response.data.decode()
-    
-    assert admin_user.email in response.data.decode()
-    assert "Profile" in response.data.decode(), "'Profile' field should appear in html, but is not."
-    assert "Change password" not in response.data.decode(), "'Change password' field should not appear in html."
+
+    assert admin_user.email in html
+    assert "Profile" in html, "'Profile' field should appear in html, but is not."
+    assert (
+        "Change password" not in html
+    ), "'Change password' field should not appear in html."
 
 
-def test_developer_applications_not_in_applications_page(services, client, app, admin_user):
+def test_developer_applications_not_in_applications_page(
+    services, client, app, admin_user
+):
     """Test that verifies Developer Applications field is not present in the applications page."""
-    
-    uploads_url = url_for("invenio_oauth2server_settings.index", _external=True) 
+
+    uploads_url = url_for("invenio_oauth2server_settings.index", _external=True)
     login_user_via_session(client, email=admin_user.email)
     response = client.get(uploads_url)
     html = response.data.decode()
-    
-    assert admin_user.email in response.data.decode()
-    assert "Applications" in response.data.decode(), "'Profile' field should appear in html, but is not."
-    assert "Developer Applications" not in response.data.decode(), "'Developer Applications' field should not appear in html."
 
+    assert admin_user.email in html
+    assert "Applications" in html, "'Profile' field should appear in html, but is not."
+    assert (
+        "Developer Applications" not in html
+    ), "'Developer Applications' field should not appear in html."

--- a/tests/ui/test_site_title.py
+++ b/tests/ui/test_site_title.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2024 NYU.
 #
 # ultraviolet is free software; you can redistribute it and/or modify it
@@ -11,10 +8,11 @@
 
 from flask import url_for
 
+
 def test_search_page_title(client, app):
     """Test that the search page includes our new title text."""
     with app.test_request_context():
-        search_url = url_for('invenio_search_ui.search')
+        search_url = url_for("invenio_search_ui.search")
 
     response = client.get(search_url)
     assert response.status_code == 200

--- a/tests/ui/test_tombstone.py
+++ b/tests/ui/test_tombstone.py
@@ -1,11 +1,11 @@
-from invenio_rdm_records.proxies import current_rdm_records_service
 from invenio_access.permissions import system_identity
-import time
+from invenio_rdm_records.proxies import current_rdm_records_service
+
 
 def test_tombstone_page(full_record, client_with_login, services, app, db):
     """
     Test for display metadata of a delete record on its tombstone page.
-    DOI is skipped. 
+    DOI is skipped.
     """
 
     service = current_rdm_records_service
@@ -20,12 +20,12 @@ def test_tombstone_page(full_record, client_with_login, services, app, db):
 
     tombstone_info = {
         "note": "A given note by staff",
-        "removal_reason": {"id": "copyright"}
+        "removal_reason": {"id": "copyright"},
     }
 
     service.delete_record(system_identity, record.id, data=tombstone_info)
 
-    response = client_with_login.get("/records/" + record['id'])
+    response = client_with_login.get("/records/" + record["id"])
     html = response.data.decode("utf-8")
 
     assert "The record you are trying to access was removed" in html
@@ -36,93 +36,93 @@ def test_tombstone_page(full_record, client_with_login, services, app, db):
 
     # Check if all metadata fields are displayed
     # **Title**
-    assert full_record['metadata']['title'] in html
+    assert full_record["metadata"]["title"] in html
 
     # **Additional Titles**
-    for title in full_record['metadata']['additional_titles']:
+    for title in full_record["metadata"]["additional_titles"]:
         assert title["title"] in html
 
     # **Description**
-    assert full_record['metadata']['description'] in html
+    assert full_record["metadata"]["description"] in html
 
     # **Additional Descriptions**
-    for desc in full_record['metadata']['additional_descriptions']:
+    for desc in full_record["metadata"]["additional_descriptions"]:
         assert desc["description"] in html
 
     # **Publication Date**
-    assert full_record['metadata']['publication_date'] in html
+    assert full_record["metadata"]["publication_date"] in html
 
     # **Publisher**
-    assert full_record['metadata']['publisher'] in html
+    assert full_record["metadata"]["publisher"] in html
 
     # **Version**
-    assert full_record['metadata']['version'] in html
+    assert full_record["metadata"]["version"] in html
 
     # **Resource Type**
-    assert 'Photo' in html
+    assert "Photo" in html
 
     # **Creators**
-    for creator in full_record['metadata']['creators']:
+    for creator in full_record["metadata"]["creators"]:
         assert creator["person_or_org"]["name"] in html
 
     # **Contributors**
-    for contributor in full_record['metadata']['contributors']:
+    for contributor in full_record["metadata"]["contributors"]:
         assert contributor["person_or_org"]["name"] in html
 
     # **Identifiers**
-    for identifier in full_record['metadata']['identifiers']:
+    for identifier in full_record["metadata"]["identifiers"]:
         assert identifier["identifier"] in html
 
     # **Related Identifiers**
-    for related in full_record['metadata']['related_identifiers']:
+    for related in full_record["metadata"]["related_identifiers"]:
         assert related["identifier"] in html
-        assert 'Is cited by' in html
+        assert "Is cited by" in html
 
     # **Dates**
-    for date in full_record['metadata']['dates']:
+    for date in full_record["metadata"]["dates"]:
         assert date["date"] in html
-        assert 'Other' in html
+        assert "Other" in html
 
     # **Languages**
-    assert 'Danish' in html
-    assert 'English' in html
+    assert "Danish" in html
+    assert "English" in html
 
     # **Subjects**
-    for subject in full_record['metadata']['subjects']:
+    for subject in full_record["metadata"]["subjects"]:
         if "id" in subject:
-            assert 'Abdominal Injuries (MeSH)' in html
+            assert "Abdominal Injuries (MeSH)" in html
         if "subject" in subject:
             assert subject["subject"] in html
 
     # **Rights**
-    for right in full_record['metadata']['rights']:
+    for right in full_record["metadata"]["rights"]:
         if "title" in right and "en" in right["title"]:
             assert right["title"]["en"] in html
         if "description" in right and "en" in right["description"]:
             assert right["description"]["en"] in html
 
     # **References**
-    for reference in full_record['metadata']['references']:
+    for reference in full_record["metadata"]["references"]:
         assert reference["reference"] in html
 
     # **Funding**
-    for funding in full_record['metadata']['funding']:
+    for funding in full_record["metadata"]["funding"]:
         assert funding["funder"]["id"] in html
         assert funding["award"]["id"] in html
 
     # **Locations**
-    for location in full_record['metadata']['locations']['features']:
+    for location in full_record["metadata"]["locations"]["features"]:
         assert location["place"] in html
         assert location["description"] in html
         for identifier in location["identifiers"]:
             assert identifier["identifier"] in html
 
     # **Sizes**
-    for size in full_record['metadata']['sizes']:
+    for size in full_record["metadata"]["sizes"]:
         assert size in html
 
     # **Formats**
-    for file_format in full_record['metadata']['formats']:
+    for file_format in full_record["metadata"]["formats"]:
         assert file_format in html
 
     # Skip checks for DOI


### PR DESCRIPTION
This PR does a bunch of clean up to the code base:

- Adds black for formatting Python files (and invent.cfg)
- Runs `black --check` in CI to enforce consistent formatting
- Reformats Python files to follow black formatting rules 
- Organizes and cleans up Python imports
- Removes redundant comments
- Test clean up
- Switch to NYU's fork of pytest-invenio (instead of my personal fork)
  - This may soon be addressed by an official pytest-invenio update: https://github.com/inveniosoftware/pytest-invenio/pull/140