### PR TITLE
Restricted geospatial records use restricted geoserver

### DIFF
--- a/assets/templates/custom_fields/GeoServerFields.js
+++ b/assets/templates/custom_fields/GeoServerFields.js
@@ -15,7 +15,8 @@ export const GeoServerFields = props => {
     has_wms,
     has_wfs,
     bounds,
-    serverUrl
+    publicServerUrl,
+    restrictedServerUrl
   } = props;
 
   const [layerName, setLayerName] = useState("")
@@ -23,12 +24,23 @@ export const GeoServerFields = props => {
   const [hasWfs, setHasWfs] = useState(false)
   const [boundingBox, setBoundingBox] = useState("")
 
+  const [serverUrl, setServerUrl] = useState("")
+
   const {values} = useFormikContext();
 
   // Listen to Formik field changes on custom fields
   // And convert them into local state
   useEffect(() => {
     let customFields = values.custom_fields;
+
+    console.log("VALUES")
+    console.log(values)
+
+    if (values.access.record == "public") {
+      setServerUrl(publicServerUrl)
+    } else {
+      setServerUrl(restrictedServerUrl)
+    }
 
     if (customFields && customFields.geoserver) {
       let geoServerFields = customFields.geoserver;

--- a/assets/templates/custom_fields/GeoServerFields.js
+++ b/assets/templates/custom_fields/GeoServerFields.js
@@ -32,10 +32,7 @@ export const GeoServerFields = props => {
   // And convert them into local state
   useEffect(() => {
     let customFields = values.custom_fields;
-
-    console.log("VALUES")
-    console.log(values)
-
+    
     if (values.access.record == "public") {
       setServerUrl(publicServerUrl)
     } else {

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -506,7 +506,11 @@ RDM_CUSTOM_FIELDS = [
         dump_options=True,
         multiple=False,
     ),
-    GeoServerCF(name="geoserver", server=GEOSERVER_PUBLIC_URL),
+    GeoServerCF(
+        name="geoserver",
+        public_server=GEOSERVER_PUBLIC_URL,
+        restricted_server=GEOSERVER_RESTRICTED_URL,
+    ),
 ]
 
 RDM_CUSTOM_FIELDS_UI = [

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -536,7 +536,8 @@ RDM_CUSTOM_FIELDS_UI = [
                 "field": "geoserver",
                 "ui_widget": "GeoServerFields",
                 "props": {
-                    "serverUrl": GEOSERVER_PUBLIC_URL,
+                    "publicServerUrl": GEOSERVER_PUBLIC_URL,
+                    "restrictedServerUrl": GEOSERVER_RESTRICTED_URL,
                     "label": _("GeoServer"),
                     "layer": {
                         "label": _("Layer Name"),

--- a/site/ultraviolet/geoserver/describe_feature_type.py
+++ b/site/ultraviolet/geoserver/describe_feature_type.py
@@ -15,11 +15,11 @@ class DescribeFeatureType(MethodView):
 
         query_string = urllib.parse.urlencode(
             {
-                "outputFormat": "application/json",
-                "request": "DescribeFeatureType",
                 "service": "WFS",
-                "typeName": layers,
                 "version": "1.1.0",
+                "request": "DescribeFeatureType",
+                "typeName": layers,
+                "outputFormat": "application/json",
             }
         )
 

--- a/site/ultraviolet/geoserver/describe_layer.py
+++ b/site/ultraviolet/geoserver/describe_layer.py
@@ -15,12 +15,12 @@ class DescribeLayer(MethodView):
 
         query_string = urllib.parse.urlencode(
             {
+                "service": "WMS",
+                "version": "1.1.1",
+                "request": "DescribeLayer",
+                "layers": layers,
                 "outputFormat": "application/json",
                 "exceptions": "application/json",
-                "request": "DescribeLayer",
-                "service": "WMS",
-                "layers": layers,
-                "version": "1.1.1",
             }
         )
 

--- a/site/ultraviolet/geoserver/fields.py
+++ b/site/ultraviolet/geoserver/fields.py
@@ -8,13 +8,18 @@ from ultraviolet.geoserver.validate import LayerValidator, BoundsValidator
 class GeoServerCF(BaseListCF):
     """GeoServer with layer and bounds."""
 
-    def __init__(self, name, server, **kwargs):
+    def __init__(self, name, public_server, restricted_server, **kwargs):
         """Constructor."""
         field_args = dict(
             dict(
                 nested=dict(
                     layer=SanitizedUnicode(
-                        validate=LayerValidator(public_server=server)
+                        validate=(
+                            LayerValidator(
+                                public_server=public_server,
+                                restricted_server=restricted_server,
+                            )
+                        )
                     ),
                     bounds=SanitizedUnicode(validate=BoundsValidator()),
                     has_wms=fields.Boolean(),

--- a/site/ultraviolet/geoserver/fields.py
+++ b/site/ultraviolet/geoserver/fields.py
@@ -13,7 +13,9 @@ class GeoServerCF(BaseListCF):
         field_args = dict(
             dict(
                 nested=dict(
-                    layer=SanitizedUnicode(validate=LayerValidator(server=server)),
+                    layer=SanitizedUnicode(
+                        validate=LayerValidator(public_server=server)
+                    ),
                     bounds=SanitizedUnicode(validate=BoundsValidator()),
                     has_wms=fields.Boolean(),
                     has_wfs=fields.Boolean(),

--- a/site/ultraviolet/geoserver/validate.py
+++ b/site/ultraviolet/geoserver/validate.py
@@ -25,7 +25,7 @@ def get_wms(server, value):
         }
     )
 
-    response = requests.get("{0}?{1}".format(url, query_string))
+    response = requests.get("{0}?{1}".format(url, query_string), timeout=3.0)
 
     return json.loads(response.text)
 
@@ -43,7 +43,7 @@ def get_wfs(server, value):
         }
     )
 
-    response = requests.get("{0}?{1}".format(url, query_string))
+    response = requests.get("{0}?{1}".format(url, query_string), timeout=3.0)
 
     return json.loads(response.text)
 
@@ -93,25 +93,46 @@ class LayerValidator(Validator):
 
         public_errors = []
 
-        if get_wms(self.public_server, value).get("exceptions") is not None:
-            public_errors.append("Can't find WMS layer named {0}.".format(value))
+        try:
+            if get_wms(self.public_server, value).get("exceptions") is not None:
+                public_errors.append("Can't find WMS layer named {0}.".format(value))
 
-        if get_wfs(self.public_server, value).get("exceptions") is not None:
-            public_errors.append("Can't find WFS layer named {0}.".format(value))
-
-        restricted_errors = []
-
-        if get_wms(self.restricted_server, value).get("exceptions") is not None:
-            restricted_errors.append("Can't find WMS layer named {0}.".format(value))
-
-        if get_wfs(self.restricted_server, value).get("exceptions") is not None:
-            restricted_errors.append("Can't find WFS layer named {0}.".format(value))
-
-        if len(public_errors) > 0 and len(restricted_errors) > 0:
+            if get_wfs(self.public_server, value).get("exceptions") is not None:
+                public_errors.append("Can't find WFS layer named {0}.".format(value))
+        except requests.exceptions.ConnectionError:
             raise ValidationError(
-                "Neither a WMS or WFS layer named {0} exists on {1} or {2}.".format(
-                    value, self.public_server, self.restricted_server
+                "Public server not reachable for validation: {0}".format(
+                    self.public_server
                 )
             )
 
-        return value
+        if len(public_errors) == 0:
+            return value
+
+        restricted_errors = []
+
+        try:
+            if get_wms(self.restricted_server, value).get("exceptions") is not None:
+                restricted_errors.append(
+                    "Can't find WMS layer named {0}.".format(value)
+                )
+
+            if get_wfs(self.restricted_server, value).get("exceptions") is not None:
+                restricted_errors.append(
+                    "Can't find WFS layer named {0}.".format(value)
+                )
+        except requests.exceptions.ConnectionError:
+            raise ValidationError(
+                "Restricted server not reachable for validation: {0}".format(
+                    self.public_server
+                )
+            )
+
+        if len(restricted_errors) == 0:
+            return value
+
+        raise ValidationError(
+            "Neither a WMS or WFS layer named {0} exists on {1} or {2}.".format(
+                value, self.public_server, self.restricted_server
+            )
+        )

--- a/site/ultraviolet/geoserver/validate.py
+++ b/site/ultraviolet/geoserver/validate.py
@@ -26,16 +26,26 @@ class BoundsValidator(Validator):
 class LayerValidator(Validator):
     default_message = "{type} layer {input} not found on {public_server}."
 
-    def __init__(self, *, public_server: str | None = None, error: str | None = None):
+    def __init__(
+        self,
+        *,
+        public_server: str | None = None,
+        restricted_server: str | None = None,
+        error: str | None = None,
+    ):
         self.public_server = public_server
+        self.restricted_server = restricted_server
         self.error: str = error or self.default_message
 
     def _repr_args(self) -> str:
-        return f"public_server={self.public_server!r}"
+        return f"public_server={self.public_server!r} restricted_server={self.restricted_server!r}"
 
     def _format_error(self, service: str, value: _T) -> str:
         return self.error.format(
-            service=service, input=value, public_server=self.public_server
+            service=service,
+            input=value,
+            public_server=self.public_server,
+            restricted_server=self.restricted_server,
         )
 
     def __call__(self, value: _T) -> _T:
@@ -45,8 +55,10 @@ class LayerValidator(Validator):
         if value is "":
             return ""
 
-        errors = []
+        public_errors = []
+        restricted_errors = []
 
+        # Public Servers
         url = "{0}/wms".format(self.public_server)
         query_string = urllib.parse.urlencode(
             {
@@ -64,7 +76,7 @@ class LayerValidator(Validator):
         data = json.loads(response.text)
 
         if data.get("exceptions") is not None:
-            errors.append("Can't find WMS layer named {0}.".format(value))
+            public_errors.append("Can't find WMS layer named {0}.".format(value))
 
         url = "{0}/wfs".format(self.public_server)
         query_string = urllib.parse.urlencode(
@@ -83,9 +95,48 @@ class LayerValidator(Validator):
         data = json.loads(response.text)
 
         if data.get("exceptions") is not None:
-            errors.append("Can't find WFS layer named {0}.".format(value))
+            public_errors.append("Can't find WFS layer named {0}.".format(value))
 
-        if len(errors) > 0:
+        # Restricted Servers
+        url = "{0}/wms".format(self.restricted_server)
+        query_string = urllib.parse.urlencode(
+            {
+                "service": "WMS",
+                "version": "1.1.1",
+                "request": "DescribeLayer",
+                "layers": value,
+                "outputFormat": "application/json",
+                "exceptions": "application/json",
+            }
+        )
+
+        full_url = "{0}?{1}".format(url, query_string)
+        response = requests.get(full_url)
+        data = json.loads(response.text)
+
+        if data.get("exceptions") is not None:
+            restricted_errors.append("Can't find WMS layer named {0}.".format(value))
+
+        url = "{0}/wfs".format(self.restricted_server)
+        query_string = urllib.parse.urlencode(
+            {
+                "service": "WFS",
+                "version": "2.0.0",
+                "request": "DescribeFeatureType",
+                "typename": value,
+                "outputFormat": "application/json",
+                "exceptions": "application/json",
+            }
+        )
+
+        full_url = "{0}?{1}".format(url, query_string)
+        response = requests.get(full_url)
+        data = json.loads(response.text)
+
+        if data.get("exceptions") is not None:
+            restricted_errors.append("Can't find WFS layer named {0}.".format(value))
+
+        if len(public_errors) > 0 and len(restricted_errors) > 0:
             raise ValidationError(
                 "Neither a WMS or WFS layer named {0} exists on {1} ".format(
                     value, self.public_server

--- a/site/ultraviolet/geoserver/validate.py
+++ b/site/ultraviolet/geoserver/validate.py
@@ -25,8 +25,7 @@ def get_wms(server, value):
         }
     )
 
-    full_url = "{0}?{1}".format(url, query_string)
-    response = requests.get(full_url)
+    response = requests.get("{0}?{1}".format(url, query_string))
 
     return json.loads(response.text)
 
@@ -44,8 +43,7 @@ def get_wfs(server, value):
         }
     )
 
-    full_url = "{0}?{1}".format(url, query_string)
-    response = requests.get(full_url)
+    response = requests.get("{0}?{1}".format(url, query_string))
 
     return json.loads(response.text)
 

--- a/site/ultraviolet/geoserver/validate.py
+++ b/site/ultraviolet/geoserver/validate.py
@@ -12,6 +12,44 @@ from marshmallow.validate import Validator
 _T = typing.TypeVar("_T")
 
 
+def get_wms(server, value):
+    url = "{0}/wms".format(server)
+    query_string = urllib.parse.urlencode(
+        {
+            "service": "WMS",
+            "version": "1.1.1",
+            "request": "DescribeLayer",
+            "layers": value,
+            "outputFormat": "application/json",
+            "exceptions": "application/json",
+        }
+    )
+
+    full_url = "{0}?{1}".format(url, query_string)
+    response = requests.get(full_url)
+
+    return json.loads(response.text)
+
+
+def get_wfs(server, value):
+    url = "{0}/wfs".format(server)
+    query_string = urllib.parse.urlencode(
+        {
+            "service": "WFS",
+            "version": "2.0.0",
+            "request": "DescribeFeatureType",
+            "typename": value,
+            "outputFormat": "application/json",
+            "exceptions": "application/json",
+        }
+    )
+
+    full_url = "{0}?{1}".format(url, query_string)
+    response = requests.get(full_url)
+
+    return json.loads(response.text)
+
+
 class BoundsValidator(Validator):
     def __call__(self, value: _T) -> _T:
         if re.match(
@@ -56,90 +94,25 @@ class LayerValidator(Validator):
             return ""
 
         public_errors = []
-        restricted_errors = []
 
-        # Public Servers
-        url = "{0}/wms".format(self.public_server)
-        query_string = urllib.parse.urlencode(
-            {
-                "service": "WMS",
-                "version": "1.1.1",
-                "request": "DescribeLayer",
-                "layers": value,
-                "outputFormat": "application/json",
-                "exceptions": "application/json",
-            }
-        )
-
-        full_url = "{0}?{1}".format(url, query_string)
-        response = requests.get(full_url)
-        data = json.loads(response.text)
-
-        if data.get("exceptions") is not None:
+        if get_wms(self.public_server, value).get("exceptions") is not None:
             public_errors.append("Can't find WMS layer named {0}.".format(value))
 
-        url = "{0}/wfs".format(self.public_server)
-        query_string = urllib.parse.urlencode(
-            {
-                "service": "WFS",
-                "version": "2.0.0",
-                "request": "DescribeFeatureType",
-                "typename": value,
-                "outputFormat": "application/json",
-                "exceptions": "application/json",
-            }
-        )
-
-        full_url = "{0}?{1}".format(url, query_string)
-        response = requests.get(full_url)
-        data = json.loads(response.text)
-
-        if data.get("exceptions") is not None:
+        if get_wfs(self.public_server, value).get("exceptions") is not None:
             public_errors.append("Can't find WFS layer named {0}.".format(value))
 
-        # Restricted Servers
-        url = "{0}/wms".format(self.restricted_server)
-        query_string = urllib.parse.urlencode(
-            {
-                "service": "WMS",
-                "version": "1.1.1",
-                "request": "DescribeLayer",
-                "layers": value,
-                "outputFormat": "application/json",
-                "exceptions": "application/json",
-            }
-        )
+        restricted_errors = []
 
-        full_url = "{0}?{1}".format(url, query_string)
-        response = requests.get(full_url)
-        data = json.loads(response.text)
-
-        if data.get("exceptions") is not None:
+        if get_wms(self.restricted_server, value).get("exceptions") is not None:
             restricted_errors.append("Can't find WMS layer named {0}.".format(value))
 
-        url = "{0}/wfs".format(self.restricted_server)
-        query_string = urllib.parse.urlencode(
-            {
-                "service": "WFS",
-                "version": "2.0.0",
-                "request": "DescribeFeatureType",
-                "typename": value,
-                "outputFormat": "application/json",
-                "exceptions": "application/json",
-            }
-        )
-
-        full_url = "{0}?{1}".format(url, query_string)
-        response = requests.get(full_url)
-        data = json.loads(response.text)
-
-        if data.get("exceptions") is not None:
+        if get_wfs(self.restricted_server, value).get("exceptions") is not None:
             restricted_errors.append("Can't find WFS layer named {0}.".format(value))
 
         if len(public_errors) > 0 and len(restricted_errors) > 0:
             raise ValidationError(
-                "Neither a WMS or WFS layer named {0} exists on {1} ".format(
-                    value, self.public_server
+                "Neither a WMS or WFS layer named {0} exists on {1} or {2}.".format(
+                    value, self.public_server, self.restricted_server
                 )
             )
 

--- a/site/ultraviolet/geoserver/validate.py
+++ b/site/ultraviolet/geoserver/validate.py
@@ -24,17 +24,19 @@ class BoundsValidator(Validator):
 
 
 class LayerValidator(Validator):
-    default_message = "{type} layer {input} not found on {server}."
+    default_message = "{type} layer {input} not found on {public_server}."
 
-    def __init__(self, *, server: str | None = None, error: str | None = None):
-        self.server = server
+    def __init__(self, *, public_server: str | None = None, error: str | None = None):
+        self.public_server = public_server
         self.error: str = error or self.default_message
 
     def _repr_args(self) -> str:
-        return f"server={self.server!r}"
+        return f"public_server={self.public_server!r}"
 
     def _format_error(self, service: str, value: _T) -> str:
-        return self.error.format(service=service, input=value, server=self.server)
+        return self.error.format(
+            service=service, input=value, public_server=self.public_server
+        )
 
     def __call__(self, value: _T) -> _T:
         if value is None:
@@ -45,7 +47,7 @@ class LayerValidator(Validator):
 
         errors = []
 
-        url = "{0}/wms".format(self.server)
+        url = "{0}/wms".format(self.public_server)
         query_string = urllib.parse.urlencode(
             {
                 "service": "WMS",
@@ -64,7 +66,7 @@ class LayerValidator(Validator):
         if data.get("exceptions") is not None:
             errors.append("Can't find WMS layer named {0}.".format(value))
 
-        url = "{0}/wfs".format(self.server)
+        url = "{0}/wfs".format(self.public_server)
         query_string = urllib.parse.urlencode(
             {
                 "service": "WFS",
@@ -86,7 +88,7 @@ class LayerValidator(Validator):
         if len(errors) > 0:
             raise ValidationError(
                 "Neither a WMS or WFS layer named {0} exists on {1} ".format(
-                    value, self.server
+                    value, self.public_server
                 )
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import os
 import sys
 
 import pytest
+import responses
 from invenio_access.proxies import current_access
 from invenio_accounts.proxies import current_datastore
 from invenio_app.factory import create_app as create_ui_api
@@ -1139,14 +1140,14 @@ def admin(UserFixture, app, db, admin_role_need):
     return u
 
 
-@pytest.fixture
+@pytest.fixture()
 def valid_wms_response():
     return {
         "version": "1.1.1",
         "layerDescriptions": [
             {
                 "layerName": "nyu_2451_41645",
-                "owsURL": "https://public.geoserver.org/geoserver/sdr/wfs?",
+                "owsURL": "https://maps-public.geo.nyu.edu/geoserver/sdr/wfs?",
                 "owsType": "WFS",
                 "typeName": "nyu_2451_41645",
             }
@@ -1154,7 +1155,7 @@ def valid_wms_response():
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def valid_wfs_response():
     return {
         "elementFormDefault": "qualified",
@@ -1178,7 +1179,7 @@ def valid_wfs_response():
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def invalid_wms_response():
     return {
         "version": "1.1.1",
@@ -1192,7 +1193,7 @@ def invalid_wms_response():
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def invalid_wfs_response():
     return {
         "version": "2.0.0",
@@ -1204,3 +1205,75 @@ def invalid_wfs_response():
             }
         ],
     }
+
+
+@pytest.fixture()
+def invalid_restricted_wfs(invalid_wfs_response):
+    responses.get(
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs",
+        json=invalid_wfs_response,
+        status=400,
+    )
+
+
+@pytest.fixture()
+def invalid_restricted_wms(invalid_wms_response):
+    responses.get(
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms",
+        json=invalid_wms_response,
+        status=200,
+    )
+
+
+@pytest.fixture()
+def valid_public_wfs(valid_wfs_response):
+    responses.get(
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wfs",
+        json=valid_wfs_response,
+        status=200,
+    )
+
+
+@pytest.fixture()
+def valid_public_wms(valid_wms_response):
+    responses.get(
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wms",
+        json=valid_wms_response,
+        status=200,
+    )
+
+
+@pytest.fixture()
+def valid_restricted_wfs(valid_wfs_response):
+    responses.get(
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs",
+        json=valid_wfs_response,
+        status=200,
+    )
+
+
+@pytest.fixture()
+def valid_restricted_wms(valid_wms_response):
+    responses.get(
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms",
+        json=valid_wms_response,
+        status=200,
+    )
+
+
+@pytest.fixture()
+def invalid_public_wfs(invalid_wfs_response):
+    responses.get(
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wfs",
+        json=invalid_wfs_response,
+        status=400,
+    )
+
+
+@pytest.fixture()
+def invalid_public_wms(invalid_wms_response):
+    responses.get(
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wms",
+        json=invalid_wms_response,
+        status=200,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1137,3 +1137,70 @@ def admin(UserFixture, app, db, admin_role_need):
     datastore.add_role_to_user(u.user, role)
     db.session.commit()
     return u
+
+
+@pytest.fixture
+def valid_wms_response():
+    return {
+        "version": "1.1.1",
+        "layerDescriptions": [
+            {
+                "layerName": "nyu_2451_41645",
+                "owsURL": "https://public.geoserver.org/geoserver/sdr/wfs?",
+                "owsType": "WFS",
+                "typeName": "nyu_2451_41645",
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def valid_wfs_response():
+    return {
+        "elementFormDefault": "qualified",
+        "targetNamespace": "geo.nyu.edu",
+        "targetPrefix": "sdr",
+        "featureTypes": [
+            {
+                "typeName": "nyu_2451_41645",
+                "properties": [
+                    {
+                        "name": "fieldname",
+                        "maxOccurs": 1,
+                        "minOccurs": 0,
+                        "nillable": True,
+                        "type": "xsd:int",
+                        "localType": "int",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def invalid_wms_response():
+    return {
+        "version": "1.1.1",
+        "exceptions": [
+            {
+                "code": "LayerNotDefined",
+                "locator": "MapLayerInfoKvpParser",
+                "text": "sdr:foo_bar: no such layer on this server",
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def invalid_wfs_response():
+    return {
+        "version": "2.0.0",
+        "exceptions": [
+            {
+                "code": "InvalidParameterValue",
+                "locator": "DescribeFeatureType",
+                "text": "Could not find type: sdr:foo_bar",
+            }
+        ],
+    }

--- a/tests/geoserver/test_validate.py
+++ b/tests/geoserver/test_validate.py
@@ -5,142 +5,175 @@ from ultraviolet.geoserver.validate import BoundsValidator
 from ultraviolet.geoserver.validate import LayerValidator
 
 
-@pytest.fixture
-def valid_wms_response():
-    return {
-        "version": "1.1.1",
-        "layerDescriptions": [
-            {
-                "layerName": "nyu_2451_41645",
-                "owsURL": "https://fake-geoserver.org/geoserver/sdr/wfs?",
-                "owsType": "WFS",
-                "typeName": "nyu_2451_41645",
-            }
-        ],
-    }
-
-
-@pytest.fixture
-def valid_wfs_response():
-    return {
-        "elementFormDefault": "qualified",
-        "targetNamespace": "geo.nyu.edu",
-        "targetPrefix": "sdr",
-        "featureTypes": [
-            {
-                "typeName": "nyu_2451_41645",
-                "properties": [
-                    {
-                        "name": "fieldname",
-                        "maxOccurs": 1,
-                        "minOccurs": 0,
-                        "nillable": True,
-                        "type": "xsd:int",
-                        "localType": "int",
-                    }
-                ],
-            }
-        ],
-    }
-
-
-@pytest.fixture
-def invalid_wms_response():
-    return {
-        "version": "1.1.1",
-        "exceptions": [
-            {
-                "code": "LayerNotDefined",
-                "locator": "MapLayerInfoKvpParser",
-                "text": "sdr:foo_bar: no such layer on this server",
-            }
-        ],
-    }
-
-
-@pytest.fixture
-def invalid_wfs_response():
-    return {
-        "version": "2.0.0",
-        "exceptions": [
-            {
-                "code": "InvalidParameterValue",
-                "locator": "DescribeFeatureType",
-                "text": "Could not find type: sdr:foo_bar",
-            }
-        ],
-    }
-
-
 def test_layer_none():
-    validator = LayerValidator(public_server="https://fake-geoserver.org/geoserver/sdr")
+    validator = LayerValidator(
+        public_server="https://public.geoserver.org/geoserver/sdr",
+        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+    )
     assert validator(None) is None
 
 
 def test_layer_empty():
-    validator = LayerValidator(public_server="https://fake-geoserver.org/geoserver/sdr")
+    validator = LayerValidator(
+        public_server="https://public.geoserver.org/geoserver/sdr",
+        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+    )
     assert validator("") is ""
 
 
 @responses.activate
-def test_layer_valid(valid_wms_response, valid_wfs_response):
+def test_only_public_layer_exists(
+    valid_wms_response, valid_wfs_response, invalid_wms_response, invalid_wfs_response
+):
     responses.add(
         method=responses.GET,
-        url="https://fake-geoserver.org/geoserver/sdr/wms",
+        url="https://public.geoserver.org/geoserver/sdr/wms",
         json=valid_wms_response,
         status=200,
     )
 
     responses.add(
         method=responses.GET,
-        url="https://fake-geoserver.org/geoserver/sdr/wfs",
+        url="https://public.geoserver.org/geoserver/sdr/wfs",
         json=valid_wfs_response,
         status=200,
     )
 
-    validator = LayerValidator(public_server="https://fake-geoserver.org/geoserver/sdr")
-    assert validator("sdr:nyu_2451_41645") == "sdr:nyu_2451_41645"
-
-
-@responses.activate
-def test_layer_invalid(invalid_wms_response, invalid_wfs_response):
     responses.add(
         method=responses.GET,
-        url="https://fake-geoserver.org/geoserver/sdr/wms",
+        url="https://restricted.geoserver.org/geoserver/sdr/wms",
         json=invalid_wms_response,
         status=200,
     )
 
     responses.add(
         method=responses.GET,
-        url="https://fake-geoserver.org/geoserver/sdr/wfs",
+        url="https://restricted.geoserver.org/geoserver/sdr/wfs",
         json=invalid_wfs_response,
         status=400,
     )
 
-    validator = LayerValidator(public_server="https://fake-geoserver.org/geoserver/sdr")
+    validator = LayerValidator(
+        public_server="https://public.geoserver.org/geoserver/sdr",
+        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+    )
+    assert validator("sdr:nyu_2451_41645") == "sdr:nyu_2451_41645"
+
+
+@responses.activate
+def test_only_restricted_layer_exists(
+    valid_wms_response, valid_wfs_response, invalid_wms_response, invalid_wfs_response
+):
+    responses.add(
+        method=responses.GET,
+        url="https://public.geoserver.org/geoserver/sdr/wms",
+        json=invalid_wms_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://public.geoserver.org/geoserver/sdr/wfs",
+        json=invalid_wfs_response,
+        status=400,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://restricted.geoserver.org/geoserver/sdr/wms",
+        json=valid_wms_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://restricted.geoserver.org/geoserver/sdr/wfs",
+        json=valid_wfs_response,
+        status=200,
+    )
+
+    validator = LayerValidator(
+        public_server="https://public.geoserver.org/geoserver/sdr",
+        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+    )
+    assert validator("sdr:nyu_2451_41645") == "sdr:nyu_2451_41645"
+
+
+@responses.activate
+def test_layer_does_not_exist(invalid_wms_response, invalid_wfs_response):
+    responses.add(
+        method=responses.GET,
+        url="https://public.geoserver.org/geoserver/sdr/wms",
+        json=invalid_wms_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://public.geoserver.org/geoserver/sdr/wfs",
+        json=invalid_wfs_response,
+        status=400,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://restricted.geoserver.org/geoserver/sdr/wms",
+        json=invalid_wms_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://restricted.geoserver.org/geoserver/sdr/wfs",
+        json=invalid_wfs_response,
+        status=400,
+    )
+
+    validator = LayerValidator(
+        public_server="https://public.geoserver.org/geoserver/sdr",
+        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+    )
 
     with pytest.raises(ValidationError):
         validator("sdr:foo_bar")
 
 
 @responses.activate
-def test_layer_half_valid(invalid_wms_response, valid_wfs_response):
+def test_only_public_wfs_exists(
+    invalid_wms_response, valid_wfs_response, invalid_wfs_response
+):
     responses.add(
         method=responses.GET,
-        url="https://fake-geoserver.org/geoserver/sdr/wms",
+        url="https://public.geoserver.org/geoserver/sdr/wms",
         json=invalid_wms_response,
         status=200,
     )
 
     responses.add(
         method=responses.GET,
-        url="https://fake-geoserver.org/geoserver/sdr/wfs",
+        url="https://public.geoserver.org/geoserver/sdr/wfs",
         json=valid_wfs_response,
         status=400,
     )
 
-    validator = LayerValidator(public_server="https://fake-geoserver.org/geoserver/sdr")
+    responses.add(
+        method=responses.GET,
+        url="https://restricted.geoserver.org/geoserver/sdr/wms",
+        json=invalid_wms_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://restricted.geoserver.org/geoserver/sdr/wfs",
+        json=invalid_wfs_response,
+        status=400,
+    )
+
+    validator = LayerValidator(
+        public_server="https://public.geoserver.org/geoserver/sdr",
+        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+    )
 
     with pytest.raises(ValidationError):
         validator("sdr:foo_bar")

--- a/tests/geoserver/test_validate.py
+++ b/tests/geoserver/test_validate.py
@@ -73,6 +73,37 @@ def test_only_public_wfs_exists(
         validator("sdr:foo_bar")
 
 
+@responses.activate
+def test_layer_connection_error_raises_validation_error():
+    responses.get(
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wms",
+        body=responses.ConnectionError("public server unreachable"),
+    )
+    responses.get(
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wfs",
+        body=responses.ConnectionError("public server unreachable"),
+    )
+    responses.get(
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms",
+        body=responses.ConnectionError("restricted server unreachable"),
+    )
+    responses.get(
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs",
+        body=responses.ConnectionError("restricted server unreachable"),
+    )
+
+    validator = LayerValidator(
+        public_server="https://maps-public.geo.nyu.edu/geoserver/sdr",
+        restricted_server="https://maps-restricted.geo.nyu.edu/geoserver/sdr",
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match="Public server not reachable for validation: https://maps-public.geo.nyu.edu/geoserver/sdr",
+    ):
+        validator("sdr:foo_bar")
+
+
 def test_bounds_valid_decimals():
     validator = BoundsValidator()
 

--- a/tests/geoserver/test_validate.py
+++ b/tests/geoserver/test_validate.py
@@ -1,137 +1,59 @@
 import pytest
 import responses
 from marshmallow import ValidationError
+
 from ultraviolet.geoserver.validate import BoundsValidator
 from ultraviolet.geoserver.validate import LayerValidator
 
 
 def test_layer_none():
     validator = LayerValidator(
-        public_server="https://public.geoserver.org/geoserver/sdr",
-        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+        public_server="https://maps-public.geo.nyu.edu/geoserver/sdr",
+        restricted_server="https://maps-restricted.geo.nyu.edu/geoserver/sdr",
     )
     assert validator(None) is None
 
 
 def test_layer_empty():
     validator = LayerValidator(
-        public_server="https://public.geoserver.org/geoserver/sdr",
-        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+        public_server="https://maps-public.geo.nyu.edu/geoserver/sdr",
+        restricted_server="https://maps-restricted.geo.nyu.edu/geoserver/sdr",
     )
     assert validator("") is ""
 
 
 @responses.activate
 def test_only_public_layer_exists(
-    valid_wms_response, valid_wfs_response, invalid_wms_response, invalid_wfs_response
+    valid_public_wms, valid_public_wfs, invalid_restricted_wms, invalid_restricted_wfs
 ):
-    responses.add(
-        method=responses.GET,
-        url="https://public.geoserver.org/geoserver/sdr/wms",
-        json=valid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://public.geoserver.org/geoserver/sdr/wfs",
-        json=valid_wfs_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://restricted.geoserver.org/geoserver/sdr/wms",
-        json=invalid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://restricted.geoserver.org/geoserver/sdr/wfs",
-        json=invalid_wfs_response,
-        status=400,
-    )
-
     validator = LayerValidator(
-        public_server="https://public.geoserver.org/geoserver/sdr",
-        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+        public_server="https://maps-public.geo.nyu.edu/geoserver/sdr",
+        restricted_server="https://maps-restricted.geo.nyu.edu/geoserver/sdr",
     )
     assert validator("sdr:nyu_2451_41645") == "sdr:nyu_2451_41645"
 
 
 @responses.activate
 def test_only_restricted_layer_exists(
-    valid_wms_response, valid_wfs_response, invalid_wms_response, invalid_wfs_response
+    invalid_public_wms, invalid_public_wfs, valid_restricted_wms, valid_restricted_wfs
 ):
-    responses.add(
-        method=responses.GET,
-        url="https://public.geoserver.org/geoserver/sdr/wms",
-        json=invalid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://public.geoserver.org/geoserver/sdr/wfs",
-        json=invalid_wfs_response,
-        status=400,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://restricted.geoserver.org/geoserver/sdr/wms",
-        json=valid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://restricted.geoserver.org/geoserver/sdr/wfs",
-        json=valid_wfs_response,
-        status=200,
-    )
-
     validator = LayerValidator(
-        public_server="https://public.geoserver.org/geoserver/sdr",
-        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+        public_server="https://maps-public.geo.nyu.edu/geoserver/sdr",
+        restricted_server="https://maps-restricted.geo.nyu.edu/geoserver/sdr",
     )
     assert validator("sdr:nyu_2451_41645") == "sdr:nyu_2451_41645"
 
 
 @responses.activate
-def test_layer_does_not_exist(invalid_wms_response, invalid_wfs_response):
-    responses.add(
-        method=responses.GET,
-        url="https://public.geoserver.org/geoserver/sdr/wms",
-        json=invalid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://public.geoserver.org/geoserver/sdr/wfs",
-        json=invalid_wfs_response,
-        status=400,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://restricted.geoserver.org/geoserver/sdr/wms",
-        json=invalid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://restricted.geoserver.org/geoserver/sdr/wfs",
-        json=invalid_wfs_response,
-        status=400,
-    )
-
+def test_layer_does_not_exist(
+    invalid_public_wms,
+    invalid_public_wfs,
+    invalid_restricted_wms,
+    invalid_restricted_wfs,
+):
     validator = LayerValidator(
-        public_server="https://public.geoserver.org/geoserver/sdr",
-        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+        public_server="https://maps-public.geo.nyu.edu/geoserver/sdr",
+        restricted_server="https://maps-restricted.geo.nyu.edu/geoserver/sdr",
     )
 
     with pytest.raises(ValidationError):
@@ -140,39 +62,11 @@ def test_layer_does_not_exist(invalid_wms_response, invalid_wfs_response):
 
 @responses.activate
 def test_only_public_wfs_exists(
-    invalid_wms_response, valid_wfs_response, invalid_wfs_response
+    invalid_public_wms, valid_public_wfs, invalid_restricted_wms, invalid_restricted_wfs
 ):
-    responses.add(
-        method=responses.GET,
-        url="https://public.geoserver.org/geoserver/sdr/wms",
-        json=invalid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://public.geoserver.org/geoserver/sdr/wfs",
-        json=valid_wfs_response,
-        status=400,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://restricted.geoserver.org/geoserver/sdr/wms",
-        json=invalid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://restricted.geoserver.org/geoserver/sdr/wfs",
-        json=invalid_wfs_response,
-        status=400,
-    )
-
     validator = LayerValidator(
-        public_server="https://public.geoserver.org/geoserver/sdr",
-        restricted_server="https://restricted.geoserver.org/geoserver/sdr",
+        public_server="https://maps-public.geo.nyu.edu/geoserver/sdr",
+        restricted_server="https://maps-restricted.geo.nyu.edu/geoserver/sdr",
     )
 
     with pytest.raises(ValidationError):

--- a/tests/geoserver/test_validate.py
+++ b/tests/geoserver/test_validate.py
@@ -73,12 +73,12 @@ def invalid_wfs_response():
 
 
 def test_layer_none():
-    validator = LayerValidator(server="https://fake-geoserver.org/geoserver/sdr")
+    validator = LayerValidator(public_server="https://fake-geoserver.org/geoserver/sdr")
     assert validator(None) is None
 
 
 def test_layer_empty():
-    validator = LayerValidator(server="https://fake-geoserver.org/geoserver/sdr")
+    validator = LayerValidator(public_server="https://fake-geoserver.org/geoserver/sdr")
     assert validator("") is ""
 
 
@@ -98,7 +98,7 @@ def test_layer_valid(valid_wms_response, valid_wfs_response):
         status=200,
     )
 
-    validator = LayerValidator(server="https://fake-geoserver.org/geoserver/sdr")
+    validator = LayerValidator(public_server="https://fake-geoserver.org/geoserver/sdr")
     assert validator("sdr:nyu_2451_41645") == "sdr:nyu_2451_41645"
 
 
@@ -118,7 +118,7 @@ def test_layer_invalid(invalid_wms_response, invalid_wfs_response):
         status=400,
     )
 
-    validator = LayerValidator(server="https://fake-geoserver.org/geoserver/sdr")
+    validator = LayerValidator(public_server="https://fake-geoserver.org/geoserver/sdr")
 
     with pytest.raises(ValidationError):
         validator("sdr:foo_bar")
@@ -140,7 +140,7 @@ def test_layer_half_valid(invalid_wms_response, valid_wfs_response):
         status=400,
     )
 
-    validator = LayerValidator(server="https://fake-geoserver.org/geoserver/sdr")
+    validator = LayerValidator(public_server="https://fake-geoserver.org/geoserver/sdr")
 
     with pytest.raises(ValidationError):
         validator("sdr:foo_bar")

--- a/tests/ui/test_map_view.py
+++ b/tests/ui/test_map_view.py
@@ -1,6 +1,5 @@
-from invenio_access.permissions import system_identity
-
 import responses
+from invenio_access.permissions import system_identity
 
 
 @responses.activate
@@ -8,39 +7,11 @@ def test_public_map_view_when_anonymous(
     services,
     geospatial_record,
     client,
-    valid_wms_response,
-    valid_wfs_response,
-    invalid_wms_response,
-    invalid_wfs_response,
+    valid_public_wms,
+    valid_public_wfs,
+    invalid_restricted_wms,
+    invalid_restricted_wfs,
 ):
-    responses.add(
-        method=responses.GET,
-        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wms",
-        json=valid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wfs",
-        json=valid_wfs_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms",
-        json=invalid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs",
-        json=invalid_wfs_response,
-        status=400,
-    )
-
     published_record = publish_draft(geospatial_record, services)
 
     html = client.get("/records/" + published_record["id"]).data.decode("utf-8")
@@ -57,46 +28,22 @@ def test_public_map_view_when_anonymous(
     )
 
 
+def setup_valid_restricted_wfs_response():
+    pass
+
+
 @responses.activate
 def test_restricted_map_view_when_logged_in(
     services,
     restricted_geospatial_record,
     client_with_login,
     app,
-    valid_wms_response,
-    valid_wfs_response,
-    invalid_wms_response,
-    invalid_wfs_response,
+    invalid_public_wms,
+    invalid_public_wfs,
+    valid_restricted_wms,
+    valid_restricted_wfs,
 ):
     app.config["APP_RDM_RECORD_LANDING_PAGE_FAIR_SIGNPOSTING_LEVEL_1_ENABLED"] = False
-
-    responses.add(
-        method=responses.GET,
-        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wms",
-        json=invalid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wfs",
-        json=invalid_wfs_response,
-        status=400,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms",
-        json=valid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs",
-        json=valid_wfs_response,
-        status=200,
-    )
 
     published_record = publish_draft(restricted_geospatial_record, services)
 
@@ -128,38 +75,11 @@ def test_restricted_map_view_when_anonymous(
     restricted_geospatial_record,
     client,
     app,
-    invalid_wms_response,
-    invalid_wfs_response,
-    valid_wms_response,
-    valid_wfs_response,
+    invalid_public_wms,
+    invalid_public_wfs,
+    valid_restricted_wms,
+    valid_restricted_wfs,
 ):
-    responses.add(
-        method=responses.GET,
-        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wms",
-        json=invalid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wfs",
-        json=invalid_wfs_response,
-        status=400,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms",
-        json=valid_wms_response,
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs",
-        json=valid_wfs_response,
-        status=200,
-    )
 
     app.config["APP_RDM_RECORD_LANDING_PAGE_FAIR_SIGNPOSTING_LEVEL_1_ENABLED"] = False
 

--- a/tests/ui/test_map_view.py
+++ b/tests/ui/test_map_view.py
@@ -1,7 +1,46 @@
 from invenio_access.permissions import system_identity
 
+import responses
 
-def test_public_map_view_when_anonymous(services, geospatial_record, client):
+
+@responses.activate
+def test_public_map_view_when_anonymous(
+    services,
+    geospatial_record,
+    client,
+    valid_wms_response,
+    valid_wfs_response,
+    invalid_wms_response,
+    invalid_wfs_response,
+):
+    responses.add(
+        method=responses.GET,
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wms",
+        json=valid_wms_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wfs",
+        json=valid_wfs_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms",
+        json=invalid_wms_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs",
+        json=invalid_wfs_response,
+        status=400,
+    )
+
     published_record = publish_draft(geospatial_record, services)
 
     html = client.get("/records/" + published_record["id"]).data.decode("utf-8")
@@ -18,10 +57,46 @@ def test_public_map_view_when_anonymous(services, geospatial_record, client):
     )
 
 
+@responses.activate
 def test_restricted_map_view_when_logged_in(
-    services, restricted_geospatial_record, client_with_login, app
+    services,
+    restricted_geospatial_record,
+    client_with_login,
+    app,
+    valid_wms_response,
+    valid_wfs_response,
+    invalid_wms_response,
+    invalid_wfs_response,
 ):
     app.config["APP_RDM_RECORD_LANDING_PAGE_FAIR_SIGNPOSTING_LEVEL_1_ENABLED"] = False
+
+    responses.add(
+        method=responses.GET,
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wms",
+        json=invalid_wms_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wfs",
+        json=invalid_wfs_response,
+        status=400,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms",
+        json=valid_wms_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs",
+        json=valid_wfs_response,
+        status=200,
+    )
 
     published_record = publish_draft(restricted_geospatial_record, services)
 
@@ -47,9 +122,45 @@ def test_restricted_map_view_when_logged_in(
     app.config["APP_RDM_RECORD_LANDING_PAGE_FAIR_SIGNPOSTING_LEVEL_1_ENABLED"] = True
 
 
+@responses.activate
 def test_restricted_map_view_when_anonymous(
-    services, restricted_geospatial_record, client, app
+    services,
+    restricted_geospatial_record,
+    client,
+    app,
+    invalid_wms_response,
+    invalid_wfs_response,
+    valid_wms_response,
+    valid_wfs_response,
 ):
+    responses.add(
+        method=responses.GET,
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wms",
+        json=invalid_wms_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://maps-public.geo.nyu.edu/geoserver/sdr/wfs",
+        json=invalid_wfs_response,
+        status=400,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms",
+        json=valid_wms_response,
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs",
+        json=valid_wfs_response,
+        status=200,
+    )
+
     app.config["APP_RDM_RECORD_LANDING_PAGE_FAIR_SIGNPOSTING_LEVEL_1_ENABLED"] = False
 
     published_record = publish_draft(restricted_geospatial_record, services)


### PR DESCRIPTION
When a Record is marked as Restricted, we need to point to the Restricted Geoserver instead of the Public one.

This now happens when validating the GeoServer Layer on both the front end and the back end.

<img width="1054" height="984" alt="Screenshot 2026-04-10 at 8 16 27 AM" src="https://github.com/user-attachments/assets/97717442-dda0-4e8e-8cf0-f8384cafd2b1" />
