### PR TITLE
Adds template for Geoserver fields so community preview doesn't break

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -534,11 +534,11 @@ RDM_CUSTOM_FIELDS_UI = [
     },
     {
         "section": "GeoServer",
-        "hide_from_landing_page": True,
         "fields": [
             {
                 "field": "geoserver",
                 "ui_widget": "GeoServerFields",
+                "template": "/geoserver.html",
                 "props": {
                     "publicServerUrl": GEOSERVER_PUBLIC_URL,
                     "restrictedServerUrl": GEOSERVER_RESTRICTED_URL,

--- a/site/ultraviolet/templates/geoserver.html
+++ b/site/ultraviolet/templates/geoserver.html
@@ -1,1 +1,8 @@
-<!-- Not currently used. This is controlled by "hide_from_landing_page" in invenio.cfg -->
+<dl class="details-list">
+    <dt class="ui tiny header">Layer Name</dt>
+    <dd>{{ field_value['layer'] }}</dd>
+    <dt class="ui tiny header">Has WMS?</dt>
+    <dd>{{ field_value['has_wms'] }}</dd>
+    <dt class="ui tiny header">Has WFS?</dt>
+    <dd>{{ field_value['has_wfs'] }}</dd>
+</dl>

--- a/tests/ui/test_map_view.py
+++ b/tests/ui/test_map_view.py
@@ -18,6 +18,7 @@ def test_public_map_view_when_anonymous(
 
     assert "Geospatial Data" in html
     assert "Web Services" in html
+    assert "Additional details" in html
 
     assert 'data-preview="True"' in html
     assert 'data-wms-url="https://maps-public.geo.nyu.edu/geoserver/sdr/wms"' in html
@@ -53,6 +54,7 @@ def test_restricted_map_view_when_logged_in(
 
     assert "Geospatial Data" in html
     assert "Web Services" in html
+    assert "Additional details" in html
 
     assert 'data-preview="True"' in html
     assert (
@@ -88,6 +90,7 @@ def test_restricted_map_view_when_anonymous(
     html = client.get("/records/" + published_record["id"]).data.decode("utf-8")
 
     assert "Geospatial Data" in html
+    assert "Additional details" in html
     assert 'data-preview="False"' in html
     assert (
         'data-bounds="ENVELOPE(-74.2556640887564, -73.700009054899, 40.9157739339836, 40.4960925239255)"'


### PR DESCRIPTION
The Preview view for Community submissions was failing due to a missing template for the additional fields.

This PR adds a small template to show the value of those fields and prevent the community preview from failing.