### PR TITLE
Restricted Files use Restricted Geoserver. Also adds field hints.

### DIFF
--- a/assets/templates/custom_fields/GeoServerFields.js
+++ b/assets/templates/custom_fields/GeoServerFields.js
@@ -25,6 +25,7 @@ export const GeoServerFields = props => {
   const [boundingBox, setBoundingBox] = useState("")
 
   const [serverUrl, setServerUrl] = useState("")
+  const [fieldHint, setFieldHint] = useState("")
 
   const {values} = useFormikContext();
 
@@ -33,7 +34,7 @@ export const GeoServerFields = props => {
   useEffect(() => {
     let customFields = values.custom_fields;
     
-    if (values.access.record == "public") {
+    if (values.access.files == "public") {
       setServerUrl(publicServerUrl)
     } else {
       setServerUrl(restrictedServerUrl)
@@ -49,6 +50,14 @@ export const GeoServerFields = props => {
       setHasWfs(!!geoServerFields.has_wfs)
     }
   }, [values]);
+
+  useEffect(() => {
+    if (serverUrl == restrictedServerUrl) {
+      setFieldHint(`Restricted files records use ${restrictedServerUrl} as the base URL for WMS and WFS requests.`)
+    } else {
+      setFieldHint(`Public files records use ${publicServerUrl} as the base URL for WMS and WFS requests.`)
+    }
+  }, [serverUrl])
 
   return (
     <Grid>
@@ -69,7 +78,7 @@ export const GeoServerFields = props => {
           <BooleanCheckbox
             fieldPath={`${fieldPath}.has_wms`}
             label={has_wms.label}
-            description={has_wms.description}
+            description={has_wms.description + " " + fieldHint}
             trueLabel="Yes"
             falseLabel="No"
           ></BooleanCheckbox>
@@ -81,7 +90,7 @@ export const GeoServerFields = props => {
           <BooleanCheckbox
             fieldPath={`${fieldPath}.has_wfs`}
             label={has_wfs.label}
-            description={has_wfs.description}
+            description={has_wfs.description + " " + fieldHint}
             trueLabel="Yes"
             falseLabel="No"
           ></BooleanCheckbox>

--- a/assets/templates/custom_fields/WfsCheck.js
+++ b/assets/templates/custom_fields/WfsCheck.js
@@ -36,7 +36,7 @@ export const WfsCheck = (
         setError(error)
         setLoading(false)
       });
-  }, [layerName]);
+  }, [layerName, serverUrl]);
 
   if (loading) {
     return <div className="ui active inverted dimmer">

--- a/assets/templates/custom_fields/WmsCheck.js
+++ b/assets/templates/custom_fields/WmsCheck.js
@@ -35,7 +35,7 @@ export const WmsCheck = (
         console.error('Error:', error);
         setLoading(false)
       });
-  }, [layerName]);
+  }, [layerName, serverUrl]);
 
   if (loading) {
     return <div className="ui active inverted dimmer">


### PR DESCRIPTION
- The usage of Public or Restricted GeoServer in the create/edit form is now based on the Files' Visibility setting, not the Record's.
- The WMS and WFS fields now show which GeoServer will be used for validation based on the Files Visibility setting
- The WMS and WFS fields will now revalidate when Files Visibility is changed (previously it was not doing this)

## Screenshots

### Public Record

<img width="764" height="792" alt="Screenshot 2026-05-04 at 9 22 59 AM" src="https://github.com/user-attachments/assets/da264614-6b41-4c27-a052-98e141d205c8" />

### Restricted Record

<img width="759" height="817" alt="Screenshot 2026-05-04 at 9 23 06 AM" src="https://github.com/user-attachments/assets/5fad14d0-03a4-4704-8018-88bde86968e9" />
