### PR TITLE
Use latest checkout, python and node actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,17 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout current state"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: "Save Python and Node versions to env"
         run: |
           echo "PYTHON_VERSION=$(cat '.python-version')" >> ${GITHUB_ENV}
           echo "NODE_VERSION=$(cat '.nvmrc')" >> ${GITHUB_ENV}
       - name: "Set up Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: "Set up Node"
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: "Install invenio-cli"


### PR DESCRIPTION
A bunch of our GitHub Actions are out of date and soon to be deprecated, so we need to update them.